### PR TITLE
Added flag and code to forcestyleliteral

### DIFF
--- a/lib/js-yaml/dumper.js
+++ b/lib/js-yaml/dumper.js
@@ -255,9 +255,6 @@ var STYLE_PLAIN   = 1,
 //    STYLE_LITERAL => no lines are suitable for folding (or lineWidth is -1).
 //    STYLE_FOLDED => a line > lineWidth and can be folded (and lineWidth != -1).
 function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, forceStyleLiteral) {
-
- 
-
   var i;
   var char;
   var hasLineBreak = false;
@@ -274,10 +271,9 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
       char = string.charCodeAt(i);
       if (!isPrintable(char)) {
         if (forceStyleLiteral) {
-          return STYLE_LITERAL
-        } else {
-          return STYLE_DOUBLE;
-        }
+          return STYLE_LITERAL;
+        } 
+        return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
     }
@@ -298,9 +294,8 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
       } else if (!isPrintable(char)) {
         if (forceStyleLiteral) {
           return STYLE_LITERAL
-        } else {
-          return STYLE_DOUBLE;
-        }
+        } 
+        return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
     }
@@ -362,7 +357,8 @@ function writeScalar(state, string, level, iskey) {
       return testImplicitResolving(state, string);
     }
 
-    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity, state.forceStyleLiteral)) {
+    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity, 
+      state.forceStyleLiteral)) {
       case STYLE_PLAIN:
         return string;
       case STYLE_SINGLE:

--- a/lib/js-yaml/dumper.js
+++ b/lib/js-yaml/dumper.js
@@ -116,7 +116,7 @@ function State(options) {
   this.noRefs        = options['noRefs'] || false;
   this.noCompatMode  = options['noCompatMode'] || false;
   this.condenseFlow  = options['condenseFlow'] || false;
-
+  this.forceStyleLiteral = options['forceStyleLiteral'] || false;
   this.implicitTypes = this.schema.compiledImplicit;
   this.explicitTypes = this.schema.compiledExplicit;
 
@@ -254,7 +254,10 @@ var STYLE_PLAIN   = 1,
 //    STYLE_PLAIN or STYLE_SINGLE => no \n are in the string.
 //    STYLE_LITERAL => no lines are suitable for folding (or lineWidth is -1).
 //    STYLE_FOLDED => a line > lineWidth and can be folded (and lineWidth != -1).
-function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType) {
+function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, forceStyleLiteral) {
+
+ 
+
   var i;
   var char;
   var hasLineBreak = false;
@@ -270,7 +273,11 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
     for (i = 0; i < string.length; i++) {
       char = string.charCodeAt(i);
       if (!isPrintable(char)) {
-        return STYLE_DOUBLE;
+        if (forceStyleLiteral) {
+          return STYLE_LITERAL
+        } else {
+          return STYLE_DOUBLE;
+        }
       }
       plain = plain && isPlainSafe(char);
     }
@@ -289,7 +296,11 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
           previousLineBreak = i;
         }
       } else if (!isPrintable(char)) {
-        return STYLE_DOUBLE;
+        if (forceStyleLiteral) {
+          return STYLE_LITERAL
+        } else {
+          return STYLE_DOUBLE;
+        }
       }
       plain = plain && isPlainSafe(char);
     }
@@ -351,7 +362,7 @@ function writeScalar(state, string, level, iskey) {
       return testImplicitResolving(state, string);
     }
 
-    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity)) {
+    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity, state.forceStyleLiteral)) {
       case STYLE_PLAIN:
         return string;
       case STYLE_SINGLE:

--- a/lib/js-yaml/dumper.js
+++ b/lib/js-yaml/dumper.js
@@ -272,7 +272,7 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
       if (!isPrintable(char)) {
         if (forceStyleLiteral) {
           return STYLE_LITERAL;
-        } 
+        }
         return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
@@ -293,8 +293,8 @@ function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, te
         }
       } else if (!isPrintable(char)) {
         if (forceStyleLiteral) {
-          return STYLE_LITERAL
-        } 
+          return STYLE_LITERAL;
+        }
         return STYLE_DOUBLE;
       }
       plain = plain && isPlainSafe(char);
@@ -357,7 +357,7 @@ function writeScalar(state, string, level, iskey) {
       return testImplicitResolving(state, string);
     }
 
-    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity, 
+    switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth, testAmbiguity,
       state.forceStyleLiteral)) {
       case STYLE_PLAIN:
         return string;


### PR DESCRIPTION
Added flag to force style literal when calling yaml.safeDump.
Invoke code with forceStyleLiteral: true to force style literal to be kept.
yaml.safeDump(res,{lorceStyleLiteral: true});
Referenced in issiue #464.

This pull request will hopefully solve it.