### PR TITLE
make esm treeshake friendly and add test

### DIFF
--- a/lib/exception.js
+++ b/lib/exception.js
@@ -22,34 +22,36 @@ function formatError(exception, compact) {
 }
 
 
-function YAMLException(reason, mark) {
-  // Super constructor
-  Error.call(this);
+var YAMLException = /*@__PURE__*/(function _() {
+  function YAMLException(reason, mark) {
+    // Super constructor
+    Error.call(this);
 
-  this.name = 'YAMLException';
-  this.reason = reason;
-  this.mark = mark;
-  this.message = formatError(this, false);
+    this.name = 'YAMLException';
+    this.reason = reason;
+    this.mark = mark;
+    this.message = formatError(this, false);
 
-  // Include stack trace in error object
-  if (Error.captureStackTrace) {
-    // Chrome and NodeJS
-    Error.captureStackTrace(this, this.constructor);
-  } else {
-    // FF, IE 10+ and Safari 6+. Fallback for others
-    this.stack = (new Error()).stack || '';
+    // Include stack trace in error object
+    if (Error.captureStackTrace) {
+      // Chrome and NodeJS
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      // FF, IE 10+ and Safari 6+. Fallback for others
+      this.stack = (new Error()).stack || '';
+    }
   }
-}
+
+  // Inherit from Error
+  YAMLException.prototype = Object.create(Error.prototype);
+  YAMLException.prototype.constructor = YAMLException;
 
 
-// Inherit from Error
-YAMLException.prototype = Object.create(Error.prototype);
-YAMLException.prototype.constructor = YAMLException;
+  YAMLException.prototype.toString = function toString(compact) {
+    return this.name + ': ' + formatError(this, compact);
+  };
 
-
-YAMLException.prototype.toString = function toString(compact) {
-  return this.name + ': ' + formatError(this, compact);
-};
-
+  return YAMLException;
+})();
 
 module.exports = YAMLException;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -120,12 +120,23 @@ function charFromCodepoint(c) {
   );
 }
 
-var simpleEscapeCheck = new Array(256); // integer, for fast access
-var simpleEscapeMap = new Array(256);
-for (var i = 0; i < 256; i++) {
-  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
-  simpleEscapeMap[i] = simpleEscapeSequence(i);
-}
+
+var _simpleEscape = /*@__PURE__*/(function _() {
+  var simpleEscapeCheck = new Array(256); // integer, for fast access
+  var simpleEscapeMap = new Array(256);
+  for (var i = 0; i < 256; i++) {
+    simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+    simpleEscapeMap[i] = simpleEscapeSequence(i);
+  }
+
+  return {
+    simpleEscapeCheck: simpleEscapeCheck,
+    simpleEscapeMap: simpleEscapeMap
+  };
+})();
+
+var simpleEscapeCheck = _simpleEscape.simpleEscapeCheck;
+var simpleEscapeMap =  _simpleEscape.simpleEscapeMap;
 
 
 function State(input, options) {

--- a/lib/schema/default.js
+++ b/lib/schema/default.js
@@ -8,7 +8,7 @@
 'use strict';
 
 
-module.exports = require('./core').extend({
+module.exports = /*@__PURE__*/require('./core').extend({
   implicit: [
     require('../type/timestamp'),
     require('../type/merge')

--- a/lib/schema/failsafe.js
+++ b/lib/schema/failsafe.js
@@ -8,7 +8,7 @@
 var Schema = require('../schema');
 
 
-module.exports = new Schema({
+module.exports = /*@__PURE__*/new Schema({
   explicit: [
     require('../type/str'),
     require('../type/seq'),

--- a/lib/schema/json.js
+++ b/lib/schema/json.js
@@ -9,7 +9,7 @@
 'use strict';
 
 
-module.exports = require('./failsafe').extend({
+module.exports = /*@__PURE__*/require('./failsafe').extend({
   implicit: [
     require('../type/null'),
     require('../type/bool'),

--- a/lib/type/binary.js
+++ b/lib/type/binary.js
@@ -116,7 +116,7 @@ function isBinary(obj) {
   return Object.prototype.toString.call(obj) ===  '[object Uint8Array]';
 }
 
-module.exports = new Type('tag:yaml.org,2002:binary', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:binary', {
   kind: 'scalar',
   resolve: resolveYamlBinary,
   construct: constructYamlBinary,

--- a/lib/type/bool.js
+++ b/lib/type/bool.js
@@ -21,7 +21,7 @@ function isBoolean(object) {
   return Object.prototype.toString.call(object) === '[object Boolean]';
 }
 
-module.exports = new Type('tag:yaml.org,2002:bool', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:bool', {
   kind: 'scalar',
   resolve: resolveYamlBoolean,
   construct: constructYamlBoolean,

--- a/lib/type/float.js
+++ b/lib/type/float.js
@@ -87,7 +87,7 @@ function isFloat(object) {
          (object % 1 !== 0 || common.isNegativeZero(object));
 }
 
-module.exports = new Type('tag:yaml.org,2002:float', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:float', {
   kind: 'scalar',
   resolve: resolveYamlFloat,
   construct: constructYamlFloat,

--- a/lib/type/int.js
+++ b/lib/type/int.js
@@ -134,7 +134,7 @@ function isInteger(object) {
          (object % 1 === 0 && !common.isNegativeZero(object));
 }
 
-module.exports = new Type('tag:yaml.org,2002:int', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:int', {
   kind: 'scalar',
   resolve: resolveYamlInteger,
   construct: constructYamlInteger,

--- a/lib/type/map.js
+++ b/lib/type/map.js
@@ -2,7 +2,7 @@
 
 var Type = require('../type');
 
-module.exports = new Type('tag:yaml.org,2002:map', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:map', {
   kind: 'mapping',
   construct: function (data) { return data !== null ? data : {}; }
 });

--- a/lib/type/merge.js
+++ b/lib/type/merge.js
@@ -6,7 +6,7 @@ function resolveYamlMerge(data) {
   return data === '<<' || data === null;
 }
 
-module.exports = new Type('tag:yaml.org,2002:merge', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:merge', {
   kind: 'scalar',
   resolve: resolveYamlMerge
 });

--- a/lib/type/null.js
+++ b/lib/type/null.js
@@ -19,7 +19,7 @@ function isNull(object) {
   return object === null;
 }
 
-module.exports = new Type('tag:yaml.org,2002:null', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:null', {
   kind: 'scalar',
   resolve: resolveYamlNull,
   construct: constructYamlNull,

--- a/lib/type/omap.js
+++ b/lib/type/omap.js
@@ -37,7 +37,7 @@ function constructYamlOmap(data) {
   return data !== null ? data : [];
 }
 
-module.exports = new Type('tag:yaml.org,2002:omap', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:omap', {
   kind: 'sequence',
   resolve: resolveYamlOmap,
   construct: constructYamlOmap

--- a/lib/type/pairs.js
+++ b/lib/type/pairs.js
@@ -46,7 +46,7 @@ function constructYamlPairs(data) {
   return result;
 }
 
-module.exports = new Type('tag:yaml.org,2002:pairs', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:pairs', {
   kind: 'sequence',
   resolve: resolveYamlPairs,
   construct: constructYamlPairs

--- a/lib/type/seq.js
+++ b/lib/type/seq.js
@@ -2,7 +2,7 @@
 
 var Type = require('../type');
 
-module.exports = new Type('tag:yaml.org,2002:seq', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:seq', {
   kind: 'sequence',
   construct: function (data) { return data !== null ? data : []; }
 });

--- a/lib/type/set.js
+++ b/lib/type/set.js
@@ -22,7 +22,7 @@ function constructYamlSet(data) {
   return data !== null ? data : {};
 }
 
-module.exports = new Type('tag:yaml.org,2002:set', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:set', {
   kind: 'mapping',
   resolve: resolveYamlSet,
   construct: constructYamlSet

--- a/lib/type/str.js
+++ b/lib/type/str.js
@@ -2,7 +2,7 @@
 
 var Type = require('../type');
 
-module.exports = new Type('tag:yaml.org,2002:str', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:str', {
   kind: 'scalar',
   construct: function (data) { return data !== null ? data : ''; }
 });

--- a/lib/type/timestamp.js
+++ b/lib/type/timestamp.js
@@ -79,7 +79,7 @@ function representYamlTimestamp(object /*, style*/) {
   return object.toISOString();
 }
 
-module.exports = new Type('tag:yaml.org,2002:timestamp', {
+module.exports = /*@__PURE__*/new Type('tag:yaml.org,2002:timestamp', {
   kind: 'scalar',
   resolve: resolveYamlTimestamp,
   construct: constructYamlTimestamp,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^7.0.0",
     "fast-check": "^2.8.0",
     "gh-pages": "^3.1.0",
+    "lodash.truncate": "^4.4.2",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "rollup": "^2.34.1",

--- a/test/issues/0631.js
+++ b/test/issues/0631.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var assert = require('assert');
+var child_process = require('child_process');
+var truncate = require('lodash.truncate');
+
+function assertPureESM(esmPath, rollupCmd = 'rollup') {
+  // verify rollup is able to have non-empty output, when not tree shakable.
+  var expected = 'const foo = "bar";\n\nexport { foo };\n';
+
+  assert.strictEqual(
+    expected,
+
+    // in normal worse case, may have lines > 1k
+    truncate(
+      child_process
+        .execSync(rollupCmd, {
+          stdio: [ 'pipe', 'pipe', 'ignore' ],
+          input: `export {} from "${esmPath}"; export const foo = "bar"; `
+        })
+        .toString(),
+      {
+        length: 4 * expected.length
+      }
+    )
+  );
+
+  // verify rollup js-yaml has empty output, aka tree shakable.
+  assert.strictEqual(
+    '\n',
+    child_process
+      .execSync(rollupCmd, {
+        stdio: [ 'pipe', 'pipe', 'ignore' ],
+        input: `export {} from "${esmPath}"`
+      })
+      .toString()
+  );
+}
+
+it('esm should be purely tree shakable', function () {
+  assertPureESM('./dist/js-yaml.mjs');
+});


### PR DESCRIPTION
### This PR
1. makes js-yaml esm treeshake friendly
2. new test added
3. **NOT** update dist, to get it easier to review
4. 2+3, leads to CI failure

### This PR + updated `dist`
1. can be found in branch https://github.com/loynoir/js-yaml/tree/feat-esm-treeshake-friendly-with-dist
2. tests pass on node10, node12, node 14, node16,  node17
3. fixed https://github.com/nodeca/js-yaml/issues/631

