### PR TITLE
Fix package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
   },
   "module": "./dist/js-yaml.mjs",
   "exports": {
-    ".": {
-      "import": "./dist/js-yaml.mjs",
-      "require": "./index.js"
-    },
+    ".": "./index.js",
+    "./import": "./dist/js-yaml.mjs",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#subpath-exports

Nested levels are not supported.