### PR TITLE
fix: resolving anchors across documents

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1552,7 +1552,7 @@ function readDocument(state) {
   state.version = null;
   state.checkLineBreaks = state.legacy;
   state.tagMap = Object.create(null);
-  state.anchorMap = Object.create(null);
+  state.anchorMap = state.anchorMap || Object.create(null);
 
   while ((ch = state.input.charCodeAt(state.position)) !== 0) {
     skipSeparationSpace(state, true, -1);

--- a/test/samples-common/resolve-anchors-across-docs.js
+++ b/test/samples-common/resolve-anchors-across-docs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = [
+  {
+    foo: 'bar'
+  },
+  {
+    foo: 'bar',
+    bar: 'baz'
+  }
+];

--- a/test/samples-common/resolve-anchors-across-docs.yml
+++ b/test/samples-common/resolve-anchors-across-docs.yml
@@ -1,0 +1,5 @@
+--- &default
+foo: bar
+---
+<< : *default
+bar: baz


### PR DESCRIPTION
```yml
--- &default
foo: bar
---
<< : *default
bar: baz
```