### PR TITLE
ci: Update to currently supported Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,17 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ '12', '14' ]
+        node-version:
+          - 14
+          - 16
+          - 18
+          - 19
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Dropped the EOL Node 12 from the testing, and added the newer versions to the matrix.
Bumped the GitHub actions to the latest versions as well