### PR TITLE
fix: tag-handle may include digits in directive

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,7 +25,7 @@ var CHOMPING_KEEP  = 3;
 var PATTERN_NON_PRINTABLE         = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
 var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
 var PATTERN_FLOW_INDICATORS       = /[,\[\]\{\}]/;
-var PATTERN_TAG_HANDLE            = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_HANDLE            = /^(?:!|!!|![a-z0-9\-]+!)$/i;
 var PATTERN_TAG_URI               = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
 
 

--- a/test/samples-common/digit-tag-directive.js
+++ b/test/samples-common/digit-tag-directive.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  'k1': 'some-string',
+  'k2': '123'
+};

--- a/test/samples-common/digit-tag-directive.yml
+++ b/test/samples-common/digit-tag-directive.yml
@@ -1,0 +1,5 @@
+%TAG !123digit! tag:yaml.org,2002:
+%TAG !a-23-1! tag:yaml.org,2002:
+---
+k1: !123digit!str some-string
+k2: !a-23-1!str 123


### PR DESCRIPTION
### What does it fix?

normal tag directive - `%TAG !taghandle! tag:yaml.org,2002:`

test case `%TAG !12345! tag:yaml.org,2002:`

- **currently** `js-yaml` throw error during parsing tag directive
- **expected** it should not throw error

reference: [c-tag-handle](https://yaml.org/spec/1.1/#c-tag-handle)

- "c-tag-handle" may be "c-named-tag-handle"
- c-named-tag-handle ::= "!" ns-word-char + "!"
- [ns-word-char](https://yaml.org/spec/1.1/#ns-word-char) defined as one of ns-dec-digit, ns-ascii-letter or "-"
- and finally `ns-dec-digit` is `[0-9]`


My references is from yaml 1.1, but these things have not been changed in yaml 1.2 spec