### PR TITLE
fix prototype pollution in merge (<<)

### DIFF
--- a/lib/js-yaml/loader.js
+++ b/lib/js-yaml/loader.js
@@ -121,6 +121,22 @@ function charFromCodepoint(c) {
   );
 }
 
+// set a property of a literal object, while protecting against prototype pollution,
+// see https://github.com/nodeca/js-yaml/issues/164 for more details
+function setProperty(object, key, value) {
+  // used for this specific key only because Object.defineProperty is slow
+  if (key === '__proto__') {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: value
+    });
+  } else {
+    object[key] = value;
+  }
+}
+
 var simpleEscapeCheck = new Array(256); // integer, for fast access
 var simpleEscapeMap = new Array(256);
 for (var i = 0; i < 256; i++) {
@@ -278,7 +294,7 @@ function mergeMappings(state, destination, source, overridableKeys) {
     key = sourceKeys[index];
 
     if (!_hasOwnProperty.call(destination, key)) {
-      destination[key] = source[key];
+      setProperty(destination, key, source[key]);
       overridableKeys[key] = true;
     }
   }
@@ -334,7 +350,7 @@ function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valu
       state.position = startPos || state.position;
       throwError(state, 'duplicated mapping key');
     }
-    _result[keyNode] = valueNode;
+    setProperty(_result, keyNode, valueNode);
     delete overridableKeys[keyNode];
   }
 

--- a/test/issues/0164.js
+++ b/test/issues/0164.js
@@ -1,0 +1,23 @@
+'use strict';
+
+
+var assert = require('assert');
+var yaml = require('../../');
+
+
+test('should define __proto__ as a value (not invoke setter)', function () {
+  var object = yaml.load('{ __proto__: {polluted: bar} }');
+
+  assert.strictEqual(({}).hasOwnProperty.call(yaml.load('{}'), '__proto__'), false);
+  assert.strictEqual(({}).hasOwnProperty.call(object, '__proto__'), true);
+  assert(!object.polluted);
+});
+
+
+test('should merge __proto__ as a value with << operator', function () {
+  var object = yaml.load('\npayload: &ref\n  polluted: bar\n\nfoo:\n  <<:\n    __proto__: *ref\n  ');
+
+  assert.strictEqual(({}).hasOwnProperty.call(yaml.load('{}'), '__proto__'), false);
+  assert.strictEqual(({}).hasOwnProperty.call(object.foo, '__proto__'), true);
+  assert(!object.foo.polluted);
+});


### PR DESCRIPTION
This PR backports https://github.com/nodeca/js-yaml/commit/383665ff4248ec2192d1274e934462bb30426879 to `v3`.

Resolves https://github.com/nodeca/js-yaml/issues/730.