### PR TITLE
fix: throw error on zero-indentation block scalar (close #280)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -902,6 +902,13 @@ function readBlockScalar(state, nodeIndent) {
       continue;
     }
 
+    // Zero-indentation block scalar is not allowed.
+    // If textIndent is still 0 at this point, it means no explicit indentation
+    // indicator was given and no indentation was detected in content lines.
+    if (!detectedIndent && textIndent === 0) {
+      throwError(state, 'missing indentation for block scalar');
+    }
+
     // End of the scalar.
     if (state.lineIndent < textIndent) {
 

--- a/test/issues/0144.js
+++ b/test/issues/0144.js
@@ -1,10 +1,10 @@
 'use strict';
 
-
 var assert = require('assert');
 var yaml   = require('../../');
 
 
 it('Infinite loop when attempting to parse multi-line scalar document that is not indented', function () {
-  assert.strictEqual(yaml.load('--- |\nfoo\n'), 'foo\n');
+  // Block scalar with zero indentation should throw an error (issue #280)
+  assert.throws(() => yaml.load('--- |\nfoo\n'), /missing indentation for block scalar/);
 });


### PR DESCRIPTION
## Summary
Fixes issue #280: Loader throws an error on zero-indentation block scalars instead of silently consuming the rest of the input.

## Problem
When a literal (`|`) or folded (`>`) block scalar has no indentation (0 spaces), the loader silently treats the rest of the input as valid YAML content. Per YAML spec, block scalars must have indentation greater than zero.

## Changes
- **lib/loader.js**: Added check in `readBlockScalar()` to throw error when block scalar has zero indentation  
- **test/issues/0144.js**: Test that verifies the error is thrown for zero-indentation literal scalars

## Testing
`npm test` passes.