### PR TITLE
fix(float): reject out-of-range values that would parse to Infinity

### DIFF
--- a/lib/type/float.js
+++ b/lib/type/float.js
@@ -24,6 +24,15 @@ function resolveYamlFloat(data) {
     return false;
   }
 
+  // Reject values that would parse to Infinity/NaN (except explicit .inf/.nan)
+  // This ensures round-trip: out-of-range ints like "61e9540" become strings
+  var value  = data.replace(/_/g, '').toLowerCase();
+  var sign   = value[0] === '-' ? -1 : 1;
+  if ('+-' .indexOf(value[0]) >= 0) value = value.slice(1);
+  if (value === '.inf' || value === '.nan') return true; // allow explicit infinity/NaN
+  var num = sign * parseFloat(value, 10);
+  if (!isFinite(num)) return false;
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

Values like `61e9540` (e.g., a git SHA) are parsed as floats and become `Infinity`, breaking round-trip as required by YAML 1.2 spec.

**Before:**
```js
yaml.load('gitsha: 61e9540') // { gitsha: Infinity }
```

**After:**
```js
yaml.load('gitsha: 61e9540') // { gitsha: '61e9540' }
```

## Fix

In `resolveYamlFloat()`, pre-check if `parseFloat(data)` would produce a finite number. Explicit `.inf`/`.nan` are still allowed. All other behavior is unchanged.

## Testing

```
61e9540 -> '61e9540' (string, not Infinity)
1e308 -> 1e308 (still finite float)
1e309 -> '1e309' (string, would otherwise be Infinity)
.inf -> Infinity (still allowed)
.nan -> NaN (still allowed)
3.14 -> 3.14 (normal floats unchanged)
```

All existing unit tests pass.

## Fixes

Fixes #737