### PR TITLE
fix(float): reject out-of-range float values to prevent Infinity

### DIFF
--- a/lib/type/float.js
+++ b/lib/type/float.js
@@ -24,6 +24,15 @@ function resolveYamlFloat(data) {
     return false;
   }
 
+  // Reject values that would parse to Infinity/NaN (except explicit .inf/.nan)
+  // This ensures round-trip: out-of-range ints like "61e9540" become strings
+  var value  = data.replace(/_/g, '').toLowerCase();
+  var sign   = value[0] === '-' ? -1 : 1;
+  if ('+-' .indexOf(value[0]) >= 0) value = value.slice(1);
+  if (value === '.inf' || value === '.nan') return true; // allow explicit infinity/NaN
+  var num = sign * parseFloat(value, 10);
+  if (!isFinite(num)) return false;
+
   return true;
 }
 

--- a/test/issues/0748.js
+++ b/test/issues/0748.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var assert = require('assert');
+var yaml = require('../../');
+
+
+describe('Float out-of-range fix', function () {
+
+  it('should reject values that would parse to Infinity', function () {
+    // These values would serialize to Infinity after round-trip
+    assert.strictEqual(yaml.load('61e9540'), '61e9540');
+    assert.strictEqual(yaml.load('1e309'), '1e309');
+    assert.strictEqual(yaml.load('-1e309'), '-1e309');
+  });
+
+  it('should still allow explicit infinity/NaN', function () {
+    assert.strictEqual(yaml.load('.inf'), Infinity);
+    assert.strictEqual(yaml.load('+.inf'), Infinity);
+    assert.strictEqual(yaml.load('-.inf'), -Infinity);
+    assert.strictEqual(yaml.load('.nan'), NaN);
+  });
+
+  it('should allow normal floats', function () {
+    assert.strictEqual(yaml.load('1.5'), 1.5);
+    assert.strictEqual(yaml.load('1e5'), 100000);
+    assert.strictEqual(yaml.load('-2.5e-3'), -0.0025);
+    assert.strictEqual(yaml.load('+.inf'), Infinity);
+  });
+
+  it('should allow floats with underscores', function () {
+    assert.strictEqual(yaml.load('1_000.5'), 1000.5);
+  });
+
+});


### PR DESCRIPTION
Fixes rejection of float values that would parse to Infinity when out of Float range.

Closes #737