### PR TITLE
chore: Add Dependabot for GitHub Actions and NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 99
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 0 * * 3'


### PR DESCRIPTION
Setup Dependabot for GitHub Actions, and bundled NPM updates. Major NPM versions would still be separate PRs.
Skip the Dependabot branches on Push to reduce the number of CI runs