### PR TITLE
Preserve object keys in !!pairs instead of stringifying to '[object Object]'

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,7 @@ const common = require('./common')
 const YAMLException = require('./exception')
 const makeSnippet = require('./snippet')
 const DEFAULT_SCHEMA = require('./schema/default')
+const pairMetadata = require('./pair-metadata')
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty
 
@@ -21,7 +22,6 @@ const PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFF
 const PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/
 // eslint-disable-next-line no-useless-escape
 const PATTERN_FLOW_INDICATORS = /[,\[\]{}]/
-// eslint-disable-next-line no-useless-escape
 const PATTERN_TAG_HANDLE = /^(?:!|!!|![0-9A-Za-z-]+!)$/
 // eslint-disable-next-line no-useless-escape
 const PATTERN_TAG_URI = /^(?:!|[^,\[\]{}])(?:%[0-9a-f]{2}|[0-9a-z\-#;/?:@&=+$,_.!~*'()\[\]])*$/i
@@ -387,8 +387,10 @@ function mergeMappings (state, destination, source, overridableKeys) {
   }
 }
 
-function storeMappingPair (state, _result, overridableKeys, keyTag, keyNode, valueNode,
+function storeMappingPair (state, _result, overridableKeys, keyTag, keyKind, keyNode, valueNode,
   startLine, startLineStart, startPos) {
+  const originalKeyNode = keyKind === 'mapping' || keyKind === 'sequence' ? keyNode : null
+
   // The output is a plain object here, so keys can only be strings.
   // We need to convert keyNode to a string, but doing so can hang the process
   // (deeply nested arrays that explode exponentially using aliases).
@@ -437,9 +439,11 @@ function storeMappingPair (state, _result, overridableKeys, keyTag, keyNode, val
       mergeMappings(state, _result, valueNode, overridableKeys)
     }
   } else {
+    const hasExistingKey = _hasOwnProperty.call(_result, keyNode)
+
     if (!state.json &&
         !_hasOwnProperty.call(overridableKeys, keyNode) &&
-        _hasOwnProperty.call(_result, keyNode)) {
+        hasExistingKey) {
       state.line = startLine || state.line
       state.lineStart = startLineStart || state.lineStart
       state.position = startPos || state.position
@@ -448,6 +452,12 @@ function storeMappingPair (state, _result, overridableKeys, keyTag, keyNode, val
 
     setProperty(_result, keyNode, valueNode)
     delete overridableKeys[keyNode]
+
+    if (!hasExistingKey && pairMetadata.has(_result)) {
+      pairMetadata.markMultiple(_result)
+    } else {
+      pairMetadata.set(_result, originalKeyNode)
+    }
   }
 
   return _result
@@ -775,6 +785,7 @@ function readFlowCollection (state, nodeIndent) {
   const overridableKeys = Object.create(null)
   let keyNode
   let keyTag
+  let keyKind
   let valueNode
 
   let ch = state.input.charCodeAt(state.position)
@@ -816,7 +827,7 @@ function readFlowCollection (state, nodeIndent) {
       throwError(state, "expected the node content, but found ','")
     }
 
-    keyTag = keyNode = valueNode = null
+    keyTag = keyKind = keyNode = valueNode = null
     isPair = isExplicitPair = false
 
     if (ch === 0x3F/* ? */) {
@@ -834,6 +845,7 @@ function readFlowCollection (state, nodeIndent) {
     _pos = state.position
     composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true)
     keyTag = state.tag
+    keyKind = state.kind
     keyNode = state.result
     skipSeparationSpace(state, true, nodeIndent)
 
@@ -848,9 +860,9 @@ function readFlowCollection (state, nodeIndent) {
     }
 
     if (isMapping) {
-      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos)
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyKind, keyNode, valueNode, _line, _lineStart, _pos)
     } else if (isPair) {
-      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos))
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyKind, keyNode, valueNode, _line, _lineStart, _pos))
     } else {
       _result.push(keyNode)
     }
@@ -1089,6 +1101,7 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
   const _result = {}
   const overridableKeys = Object.create(null)
   let keyTag = null
+  let keyKind = null
   let keyNode = null
   let valueNode = null
   let atExplicitKey = false
@@ -1120,8 +1133,8 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
     if ((ch === 0x3F/* ? */ || ch === 0x3A/* : */) && isWsOrEol(following)) {
       if (ch === 0x3F/* ? */) {
         if (atExplicitKey) {
-          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos)
-          keyTag = keyNode = valueNode = null
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyKind, keyNode, null, _keyLine, _keyLineStart, _keyPos)
+          keyTag = keyKind = keyNode = valueNode = null
         }
 
         detected = true
@@ -1167,14 +1180,15 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
           }
 
           if (atExplicitKey) {
-            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos)
-            keyTag = keyNode = valueNode = null
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyKind, keyNode, null, _keyLine, _keyLineStart, _keyPos)
+            keyTag = keyKind = keyNode = valueNode = null
           }
 
           detected = true
           atExplicitKey = false
           allowCompact = false
           keyTag = state.tag
+          keyKind = state.kind
           keyNode = state.result
         } else if (detected) {
           throwError(state, 'can not read an implicit mapping pair; a colon is missed')
@@ -1204,6 +1218,7 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
 
       if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
         if (atExplicitKey) {
+          keyKind = state.kind
           keyNode = state.result
         } else {
           valueNode = state.result
@@ -1211,8 +1226,8 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
       }
 
       if (!atExplicitKey) {
-        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos)
-        keyTag = keyNode = valueNode = null
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyKind, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos)
+        keyTag = keyKind = keyNode = valueNode = null
       }
 
       skipSeparationSpace(state, true, -1)
@@ -1232,7 +1247,7 @@ function readBlockMapping (state, nodeIndent, flowIndent) {
 
   // Special case: last mapping's node contains only the key in explicit notation.
   if (atExplicitKey) {
-    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos)
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyKind, keyNode, null, _keyLine, _keyLineStart, _keyPos)
   }
 
   // Expose the resulting mapping.

--- a/lib/pair-metadata.js
+++ b/lib/pair-metadata.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const pairKeyNodeByMapping = new WeakMap()
+const mappingsWithMultipleKeys = new WeakSet()
+
+function setPairKeyNode (mapping, keyNode) {
+  if (mappingsWithMultipleKeys.has(mapping)) return
+
+  pairKeyNodeByMapping.set(mapping, keyNode)
+}
+
+function getPairKeyNode (mapping) {
+  return pairKeyNodeByMapping.get(mapping)
+}
+
+function hasPairKeyNode (mapping) {
+  return pairKeyNodeByMapping.has(mapping)
+}
+
+function markMappingWithMultipleKeys (mapping) {
+  pairKeyNodeByMapping.delete(mapping)
+  mappingsWithMultipleKeys.add(mapping)
+}
+
+module.exports.set = setPairKeyNode
+module.exports.get = getPairKeyNode
+module.exports.has = hasPairKeyNode
+module.exports.markMultiple = markMappingWithMultipleKeys

--- a/lib/type/pairs.js
+++ b/lib/type/pairs.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Type = require('../type')
+const pairMetadata = require('../pair-metadata')
 
 const _toString = Object.prototype.toString
 
@@ -36,8 +37,17 @@ function constructYamlPairs (data) {
     const pair = object[index]
 
     const keys = Object.keys(pair)
+    let key = keys[0]
 
-    result[index] = [keys[0], pair[keys[0]]]
+    if (pairMetadata.has(pair)) {
+      const pairKey = pairMetadata.get(pair)
+
+      if (pairKey !== null) {
+        key = pairKey
+      }
+    }
+
+    result[index] = [key, pair[keys[0]]]
   }
 
   return result

--- a/test/core/issues/0481.js
+++ b/test/core/issues/0481.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { it } = require('node:test')
+
+const assert = require('assert')
+const yaml = require('js-yaml')
+
+it('Preserve object keys in !!pairs', function () {
+  const result = yaml.load(`
+pairs: !!pairs
+  - { test: 123 }: { test: 123 }
+  - scalar: value
+  - 123: numeric
+  - { test: 456 }: { test: 456 }
+flow: !!pairs [ { flow: key }: { flow: value }, plain: scalar ]
+timestamp: !!pairs
+  - 2001-12-15: date
+`)
+
+  assert.deepStrictEqual(result.pairs[0], [{ test: 123 }, { test: 123 }])
+  assert.deepStrictEqual(result.pairs[1], ['scalar', 'value'])
+  assert.deepStrictEqual(result.pairs[2], ['123', 'numeric'])
+  assert.deepStrictEqual(result.pairs[3], [{ test: 456 }, { test: 456 }])
+
+  assert.deepStrictEqual(result.flow[0], [{ flow: 'key' }, { flow: 'value' }])
+  assert.deepStrictEqual(result.flow[1], ['plain', 'scalar'])
+
+  assert.strictEqual(result.timestamp[0][0], String(new Date(Date.UTC(2001, 11, 15))))
+  assert.strictEqual(result.timestamp[0][1], 'date')
+})


### PR DESCRIPTION
Fixes #481.

A `!!pairs` item whose key is a flow mapping (an object) was stringified to `'[object Object]'`, because by the time the `!!pairs` constructor runs, the loader has already converted the key to a plain-object string key.

This captures the original key node in the loader for object/sequence keys (kept in a `WeakMap` side-table so it is garbage-collected with the mapping and does not change behavior for normal mappings), and the `!!pairs` constructor recovers it. Scalar, numeric, and timestamp keys keep their existing string behavior.

Added `test/core/issues/0481.js` covering object keys, scalar keys, numeric keys, flow style, and timestamp keys. Full suite passes.

This is a non-trivial change to the loader; happy to gate the metadata tracking more narrowly (e.g. only when a `!!pairs` tag is involved) if you prefer a lighter touch.

Prepared with AI assistance.