### PR TITLE
Quote scalars that look like a document-separator line

### DIFF
--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -176,6 +176,14 @@ function testImplicitResolving (state, str) {
   return false
 }
 
+// A plain scalar equal to "---" or "..." at the start of a line is parsed as a
+// directives-end / document-end marker (see [206] c-forbidden in the spec, and
+// testDocumentSeparator() in the loader), so such a string must be quoted to
+// survive a round trip.
+function isDocumentSeparator (string) {
+  return string === '---' || string === '...'
+}
+
 // [33] s-white ::= s-space | s-tab
 function isWhitespace (c) {
   return c === CHAR_SPACE || c === CHAR_TAB
@@ -417,7 +425,7 @@ function writeScalar (state, string, level, iskey, inblock) {
       // No block styles in flow mode.
       (state.flowLevel > -1 && level >= state.flowLevel)
     function testAmbiguity (string) {
-      return testImplicitResolving(state, string)
+      return isDocumentSeparator(string) || testImplicitResolving(state, string)
     }
 
     switch (chooseScalarStyle(string, singleLineOnly, state.indent, lineWidth,

--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -176,12 +176,14 @@ function testImplicitResolving (state, str) {
   return false
 }
 
-// A plain scalar equal to "---" or "..." at the start of a line is parsed as a
-// directives-end / document-end marker (see [206] c-forbidden in the spec, and
-// testDocumentSeparator() in the loader), so such a string must be quoted to
-// survive a round trip.
+// A plain scalar whose first line begins with "---" or "..." followed by
+// whitespace or the end of the line is parsed as a directives-end / document-end
+// marker (see [206] c-forbidden in the spec, and testDocumentSeparator() in the
+// loader), so such a string must be quoted to survive a round trip.
+const DOCUMENT_SEPARATOR = /^(---|\.\.\.)(\s|$)/
+
 function isDocumentSeparator (string) {
-  return string === '---' || string === '...'
+  return DOCUMENT_SEPARATOR.test(string)
 }
 
 // [33] s-white ::= s-space | s-tab

--- a/test/core/20-dumper.test.js
+++ b/test/core/20-dumper.test.js
@@ -38,6 +38,12 @@ describe('Dumper', function () {
       assert.strictEqual(yaml.load(yaml.dump({ key: value })).key, value)
     })
 
+    // A marker followed by whitespace is also a separator line, so these must
+    // round-trip too (mirrors testDocumentSeparator() in the loader).
+    ;['... x', '--- x'].forEach(function (value) {
+      assert.strictEqual(yaml.load(yaml.dump(value)), value)
+    })
+
     // Strings that merely resemble markers must stay plain (no over-quoting).
     assert.strictEqual(yaml.dump('...x'), '...x\n')
     assert.strictEqual(yaml.dump('....'), '....\n')

--- a/test/core/20-dumper.test.js
+++ b/test/core/20-dumper.test.js
@@ -28,4 +28,19 @@ describe('Dumper', function () {
       }
     })
   })
+
+  it('should quote scalars that look like document markers', function () {
+    // A plain scalar equal to "..." or "---" at the start of a line would be
+    // re-read as a document-end / directives-end marker, breaking round-trip.
+    ;['...', '---'].forEach(function (value) {
+      assert.strictEqual(yaml.load(yaml.dump(value)), value)
+      assert.strictEqual(yaml.load(yaml.dump([value]))[0], value)
+      assert.strictEqual(yaml.load(yaml.dump({ key: value })).key, value)
+    })
+
+    // Strings that merely resemble markers must stay plain (no over-quoting).
+    assert.strictEqual(yaml.dump('...x'), '...x\n')
+    assert.strictEqual(yaml.dump('....'), '....\n')
+    assert.strictEqual(yaml.dump('x...'), 'x...\n')
+  })
 })


### PR DESCRIPTION
### Problem

`yaml.dump()` emits a plain scalar for strings that the parser then reads as a document separator, breaking the round trip:

```js
yaml.load(yaml.dump('...'))    // => null   (expected '...')
yaml.load(yaml.dump('... x'))  // => throws "expected a single document in the stream, but found more"
```

The dumper guarded only the exact strings `'---'` / `'...'`, but the loader's `testDocumentSeparator()` treats `---`/`...` at the start of a line **followed by whitespace or end-of-line** as a separator. So `... x`, `--- x`, etc. slipped through as plain scalars.

### Fix

Mirror the loader's rule in the dumper (`/^(---|\.\.\.)(\s|$)/`) so any scalar whose first line is a document-separator line is quoted. Strings that merely resemble markers (`...x`, `....`, `x...`) stay plain — no over-quoting.

Added round-trip assertions for `...`, `---`, `... x`, `--- x` and negative cases. `npm test` (lint + core + build) passes.