### PR TITLE
feat: add `maxMergeSeqLength = 20` option in v3

### DIFF
--- a/lib/js-yaml/loader.js
+++ b/lib/js-yaml/loader.js
@@ -155,6 +155,8 @@ function State(input, options) {
   this.json      = options['json']      || false;
   this.listener  = options['listener']  || null;
 
+  this.maxMergeSeqLength = typeof options['maxMergeSeqLength'] === 'number' ? options['maxMergeSeqLength'] : 20;
+
   this.implicitTypes = this.schema.compiledImplicit;
   this.typeMap       = this.schema.compiledTypeMap;
 
@@ -336,6 +338,10 @@ function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valu
 
   if (keyTag === 'tag:yaml.org,2002:merge') {
     if (Array.isArray(valueNode)) {
+      if (valueNode.length > state.maxMergeSeqLength) {
+        throwError(state, 'merge sequence length exceeded maxMergeSeqLength (' + state.maxMergeSeqLength + ')');
+      }
+
       for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
         mergeMappings(state, _result, valueNode[index], overridableKeys);
       }

--- a/test/units/loader-parameters.js
+++ b/test/units/loader-parameters.js
@@ -52,3 +52,50 @@ suite('loader parameters', function () {
     assert.deepEqual(result, expected);
   });
 });
+
+// Builds a YAML string with a merge sequence of `count` anchored mappings
+function buildMergeSeqYaml(count) {
+  var repeated = '*a, '.repeat(count);
+
+  return [
+    'a: &a { k: 0 }',
+    'b: { <<: [ ' + repeated + '*a ] }'
+  ].join('\n');
+}
+
+suite('maxMergeSeqLength option', function () {
+  test('merge sequence within default limit (20) should succeed', function () {
+    var input = buildMergeSeqYaml(19);
+    assert.doesNotThrow(function () {
+      yaml.safeLoad(input);
+    });
+  });
+
+  test('merge sequence exceeding default limit (20) should throw', function () {
+    var input = buildMergeSeqYaml(20);
+    assert.throws(function () {
+      yaml.safeLoad(input);
+    }, /merge sequence length exceeded maxMergeSeqLength \(20\)/);
+  });
+
+  test('custom maxMergeSeqLength allows longer sequences', function () {
+    var input = buildMergeSeqYaml(29);
+    assert.doesNotThrow(function () {
+      yaml.safeLoad(input, { maxMergeSeqLength: 30 });
+    });
+  });
+
+  test('custom maxMergeSeqLength rejects sequences that exceed it', function () {
+    var input = buildMergeSeqYaml(4);
+    assert.throws(function () {
+      yaml.safeLoad(input, { maxMergeSeqLength: 4 });
+    }, /merge sequence length exceeded maxMergeSeqLength \(4\)/);
+  });
+
+  test('merge sequence within custom limit should succeed', function () {
+    var input = buildMergeSeqYaml(3);
+    assert.doesNotThrow(function () {
+      yaml.safeLoad(input, { maxMergeSeqLength: 4 });
+    });
+  });
+});


### PR DESCRIPTION
This backports https://github.com/nodeca/js-yaml/commit/3de1b7699fbf8f726c23852993221246521a6c3e to v3 allowing GHSA-h67p-54hq-rp68 to be resolved downstream more easily.

While I would really like to just upgrade everything to v4, the change lands very cleanly and there's still a lot of use of v3 so I figured I'd see if people were open to releasing this :)

Resolves #762