### PR TITLE
fix: quote dumped strings that YAML 1.1 reads as underscore numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Quote dumped strings that YAML 1.1 parsers would resolve as numbers with
+  underscores, keeping output round-trip safe across parsers, #760.
+
+
 ## [4.2.0] - 2026-06-01
 ### Added
 - Added `docs/safety.md` with notes about processing untrusted YAML.

--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -58,6 +58,15 @@ const DEPRECATED_BOOLEANS_SYNTAX = [
 
 const DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/
 
+// Underscores in numbers used to be resolved as numeric scalars (YAML 1.1), but
+// no longer are (see #627). These forms still resolve as numbers in YAML 1.1
+// parsers (PyYAML, libyaml, Psych) and in js-yaml <= 4.1.1, so a plain string
+// matching one of them would not round-trip cross-parser and must be quoted.
+// Mirrors the pre-#627 loader: decimal int/float, hex/octal/binary, no trailing
+// underscore. The parseFloat check rejects degenerate forms (e.g. `._e0`).
+const DEPRECATED_UNDERSCORE_NUMBER_SYNTAX =
+  /^(?:[-+]?[0-9][0-9_]*(?:\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?0x[0-9a-fA-F_]+|[-+]?0o[0-7_]+|[-+]?0b[01_]+)$/
+
 function compileStyleMap (schema, map) {
   if (map === null) return {}
 
@@ -162,6 +171,16 @@ function indentString (string, spaces) {
 
 function generateNextLine (state, level) {
   return '\n' + common.repeat(' ', state.indent * level)
+}
+
+// A plain string that a YAML 1.1 parser would read as a number because of digit
+// group underscores (see DEPRECATED_UNDERSCORE_NUMBER_SYNTAX). Underscores at the
+// end were never resolved, and the value must reduce to a finite number.
+function isDeprecatedUnderscoreNumber (str) {
+  return str.indexOf('_') !== -1 &&
+    str[str.length - 1] !== '_' &&
+    DEPRECATED_UNDERSCORE_NUMBER_SYNTAX.test(str) &&
+    Number.isFinite(parseFloat(str.replace(/_/g, '')))
 }
 
 function testImplicitResolving (state, str) {
@@ -395,7 +414,9 @@ function writeScalar (state, string, level, iskey, inblock) {
       return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''"
     }
     if (!state.noCompatMode) {
-      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string)) {
+      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 ||
+          DEPRECATED_BASE60_SYNTAX.test(string) ||
+          isDeprecatedUnderscoreNumber(string)) {
         return state.quotingType === QUOTING_TYPE_DOUBLE ? ('"' + string + '"') : ("'" + string + "'")
       }
     }

--- a/test/core/issues/0760.js
+++ b/test/core/issues/0760.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { it } = require('node:test')
+
+const assert = require('assert')
+const yaml = require('js-yaml')
+
+it('Should quote strings that YAML 1.1 parsers would resolve as numbers', function () {
+  // Numbers with underscores are no longer resolved as numeric scalars (#627),
+  // but YAML 1.1 parsers (and js-yaml <= 4.1.1) still do, so dumping them plain
+  // would not round-trip cross-parser. They must be quoted.
+  assert.strictEqual(yaml.dump({ test: '0_30' }), "test: '0_30'\n")
+  assert.strictEqual(yaml.dump({ test: '1_000' }), "test: '1_000'\n")
+  assert.strictEqual(yaml.dump({ test: '0x1_F' }), "test: '0x1_F'\n")
+  assert.strictEqual(yaml.dump({ test: '0o7_7' }), "test: '0o7_7'\n")
+  assert.strictEqual(yaml.dump({ test: '0b1_0' }), "test: '0b1_0'\n")
+  assert.strictEqual(yaml.dump({ test: '1_2.3_4' }), "test: '1_2.3_4'\n")
+
+  // Forms a YAML 1.1 parser never resolved (leading/trailing underscore, or not
+  // a number) stay plain.
+  assert.strictEqual(yaml.dump({ test: '_30' }), 'test: _30\n')
+  assert.strictEqual(yaml.dump({ test: '30_' }), 'test: 30_\n')
+  assert.strictEqual(yaml.dump({ test: 'hello_world' }), 'test: hello_world\n')
+
+  // Round-trips through this (YAML 1.2) parser as well.
+  assert.deepStrictEqual(yaml.load(yaml.dump({ test: '0_30' })), { test: '0_30' })
+})


### PR DESCRIPTION
Closes #760

## Problem

`yaml.dump({ test: '0_30' })` emits `test: 0_30` **unquoted**:

```js
yaml.dump({ test: '0_30' })
// before: "test: 0_30\n"
```

YAML 1.1 parsers (PyYAML, libyaml, Psych) and js-yaml ≤ 4.1.1 resolve `0_30` as the integer `30`, so the unquoted output is no longer round-trip safe across parsers — the string silently becomes a number when read elsewhere.

This regressed as a **side effect** of #627. That commit correctly made the loader YAML-1.2-compliant: `lib/type/int.js` / `float.js` no longer resolve numbers with underscores. As a consequence, the dumper's `testImplicitResolving` no longer flags these strings, so `chooseScalarStyle` emits them plain.

**This PR does not revert #627.** The loader change is intentional and correct, and is left untouched. The fix is entirely in the dumper: it restores cross-parser round-trip safety by *quoting* a plain string that a YAML 1.1 parser would read as a number.

## Fix

Add a dumper guard mirroring the existing `DEPRECATED_BASE60_SYNTAX` guard in `writeScalar` (it sits in the same `!noCompatMode` block, alongside the deprecated-boolean and base-60 guards). The new `DEPRECATED_UNDERSCORE_NUMBER_SYNTAX` regex + `isDeprecatedUnderscoreNumber` predicate reproduce the **pre-#627 loader semantics** exactly: decimal int/float, hex/octal/binary, with no trailing underscore, reducing to a finite number. So only the forms a YAML 1.1 parser actually resolved as numbers get quoted.

```js
yaml.dump({ test: '0_30' })
// after: "test: '0_30'\n"
```

Forms YAML 1.1 never resolved stay plain (no over-quoting):

| input | before | after |
|---|---|---|
| `'0_30'` | `0_30` | `'0_30'` |
| `'1_000'` | `1_000` | `'1_000'` |
| `'0x1_F'` | `0x1_F` | `'0x1_F'` |
| `'_30'` | `_30` | `_30` (unchanged) |
| `'30_'` | `30_` | `30_` (unchanged) |
| `'hello_world'` | `hello_world` | `hello_world` (unchanged) |

`{ forceQuotes: true }` already quoted these; this addresses the *implicit* quoting decision. `{ noCompatMode: true }` still opts out, consistent with the existing base-60 / boolean compat behavior.

## Test

Added `test/core/issues/0760.js` (auto-required by the issues runner). Verified fails-before / passes-after: reverting just the dumper change makes it fail with `actual: 'test: 0_30\n'` vs `expected: "test: '0_30'\n"`; re-applying makes it pass.

## Full test suite (`npm test`)

```
> npm run lint  → 0 errors (1 pre-existing warning in loader.js, unrelated)

> test:core
ℹ tests 304
ℹ suites 26
ℹ pass 303
ℹ fail 0
ℹ skipped 1

> test:build
ℹ tests 6
ℹ pass 6
ℹ fail 0
```

---

Prepared with AI assistance (Claude Code), reviewed by the author.
