### PR TITLE
Fix dump of whole-document scalar made only of line breaks

### DIFF
--- a/lib/dumper.js
+++ b/lib/dumper.js
@@ -427,10 +427,10 @@ function writeScalar (state, string, level, iskey, inblock) {
       case STYLE_SINGLE:
         return "'" + string.replace(/'/g, "''") + "'"
       case STYLE_LITERAL:
-        return '|' + blockHeader(string, state.indent) +
+        return '|' + blockHeader(string, state.indent, level === 0) +
           dropEndingNewline(indentString(string, indent))
       case STYLE_FOLDED:
-        return '>' + blockHeader(string, state.indent) +
+        return '>' + blockHeader(string, state.indent, level === 0) +
           dropEndingNewline(indentString(foldString(string, lineWidth), indent))
       case STYLE_DOUBLE:
         return '"' + escapeString(string, lineWidth) + '"'
@@ -441,8 +441,19 @@ function writeScalar (state, string, level, iskey, inblock) {
 }
 
 // Pre-conditions: string is valid for a block scalar, 1 <= indentPerLevel <= 9.
-function blockHeader (string, indentPerLevel) {
-  const indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : ''
+function blockHeader (string, indentPerLevel, atRoot) {
+  let indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : ''
+
+  // A block scalar made up entirely of line breaks has no non-empty line for
+  // the parser to detect indentation from. When nested it parses fine (the
+  // parent node fixes the indentation), but as a whole document it has no
+  // parent, so `|+` followed by blank lines is rejected with "missing
+  // indentation for block scalar". Emit an explicit indicator in that case.
+  // The exact width is irrelevant since there is no content to indent, so it is
+  // clamped to a single digit to stay within the spec's allowed range.
+  if (atRoot && !indentIndicator && /^\n+$/.test(string)) {
+    indentIndicator = String(Math.min(indentPerLevel, 9))
+  }
 
   // note the special case: the string '\n' counts as a "trailing" empty line.
   const clip = string[string.length - 1] === '\n'

--- a/test/core/units/dump-scalar-styles.js
+++ b/test/core/units/dump-scalar-styles.js
@@ -82,8 +82,13 @@ describe('Scalar style dump:', function () {
     it('preserves trailing newlines using chomping', function () {
       assert.strictEqual(yaml.dump({ a: '\n', b: '\n\n', c: 'c\n', d: 'd\nd' }),
         'a: |+\n\nb: |+\n\n\nc: |\n  c\nd: |-\n  d\n  d\n')
-      assert.strictEqual(yaml.dump('\n'), '|+\n' + '\n')
-      assert.strictEqual(yaml.dump('\n\n'), '|+\n' + '\n\n')
+      // A whole-document scalar made up only of line breaks needs an explicit
+      // indentation indicator. Without it the emitted `|+` followed by blank
+      // lines cannot be parsed back ("missing indentation for block scalar").
+      assert.strictEqual(yaml.dump('\n'), '|2+\n' + '\n')
+      assert.strictEqual(yaml.dump('\n\n'), '|2+\n' + '\n\n')
+      assert.strictEqual(yaml.load(yaml.dump('\n')), '\n')
+      assert.strictEqual(yaml.load(yaml.dump('\n\n')), '\n\n')
 
       assert.strictEqual(yaml.dump(content), '|-\n' + indented + '\n')
       assert.strictEqual(yaml.dump(content + '\n'), '|\n' + indented + '\n')


### PR DESCRIPTION
When the input is a string consisting **only of line breaks**, `dump()` produced output that the loader cannot parse, so the round trip throws:

```js
const yaml = require("js-yaml");

yaml.load(yaml.dump("\n"));     // throws: missing indentation for block scalar (3:1)
yaml.load(yaml.dump("\n\n"));   // throws
```

`dump("\n")` emits:

```
|+

```

i.e. a literal block scalar with the `+` (keep) chomping indicator but **no indentation indicator**, followed by blank lines. A block scalar made up entirely of line breaks has no non-empty line, so the parser cannot auto-detect the content indentation. When the scalar is nested under a mapping/sequence key the parent node pins the indentation and it parses fine, but as a whole document there is no parent, so the loader rejects it via the same guard added in `4ed3479` ("Reject top-level block scalars without content indentation", #280).

### Fix

`blockHeader()` now emits an explicit indentation indicator for top-level scalars that consist only of line breaks. The indicator width is irrelevant in this case (there is no content to indent), so it is clamped to a single digit to stay within the spec's allowed range. Output for nested scalars is unchanged.

```js
yaml.dump("\n");    // "|2+\n\n"   ->  loads back as "\n"
yaml.dump("\n\n");  // "|2+\n\n\n" ->  loads back as "\n\n"
```

### Tests

`test/core/units/dump-scalar-styles.js` previously asserted the broken `|+` output (it only checked the dump string, never the round trip). Updated to the corrected output and added round-trip assertions (`yaml.load(yaml.dump("\n")) === "\n"`). The test fails on `master` without the dumper change and passes with it.

Verified with a 400k-case dump→load fuzz over short strings of YAML-significant characters: parse-throw failures drop from 1685 to **0**, with no change to any other round-trip result. Full suite (`npm test`: lint + core + build) is green.