### PR TITLE
fix: round-trip integers that stringify in exponential notation

### DIFF
--- a/src/tag/scalar/float_core.ts
+++ b/src/tag/scalar/float_core.ts
@@ -51,7 +51,10 @@ const floatCoreTag = defineScalarTag('tag:yaml.org,2002:float', {
   implicitFirstChars: ['-', '+', '.', ...'0123456789'],
   resolve: resolveYamlFloat,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 !== 0 || Object.is(object, -0)),
+    // Also claim integer-valued numbers that stringify in exponential notation
+    // (>= 1e21), since their `!!int` text would be invalid; `represent` emits a
+    // valid float form for them.
+    (object % 1 !== 0 || Object.is(object, -0) || /e/i.test(object.toString(10))),
   represent: representYamlFloat
 })
 

--- a/src/tag/scalar/float_json.ts
+++ b/src/tag/scalar/float_json.ts
@@ -57,7 +57,10 @@ const floatJsonTag = defineScalarTag('tag:yaml.org,2002:float', {
   implicitFirstChars: ['-', ...'0123456789'],
   resolve: resolveYamlFloat,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 !== 0 || Object.is(object, -0)),
+    // Also claim integer-valued numbers that stringify in exponential notation
+    // (>= 1e21), since their `!!int` text would be invalid; `represent` emits a
+    // valid float form for them.
+    (object % 1 !== 0 || Object.is(object, -0) || /e/i.test(object.toString(10))),
   represent: representYamlFloat
 })
 

--- a/src/tag/scalar/float_yaml11.ts
+++ b/src/tag/scalar/float_yaml11.ts
@@ -58,7 +58,10 @@ const floatYaml11Tag = defineScalarTag('tag:yaml.org,2002:float', {
   implicitFirstChars: ['-', '+', '.', ...'0123456789'],
   resolve: resolveYamlFloat,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 !== 0 || Object.is(object, -0)),
+    // Also claim integer-valued numbers that stringify in exponential notation
+    // (>= 1e21), since their `!!int` text would be invalid; `represent` emits a
+    // valid float form for them.
+    (object % 1 !== 0 || Object.is(object, -0) || /e/i.test(object.toString(10))),
   represent: representYamlFloat
 })
 

--- a/src/tag/scalar/int_core.ts
+++ b/src/tag/scalar/int_core.ts
@@ -54,7 +54,9 @@ const intCoreTag = defineScalarTag('tag:yaml.org,2002:int', {
   implicitFirstChars: ['-', '+', ...'0123456789'],
   resolve: resolveYamlInteger,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 === 0 && !Object.is(object, -0)),
+    // Large integers (>= 1e21) stringify in exponential notation, which is not
+    // valid `!!int` text. Reject them here so they fall through to the float tag.
+    (object % 1 === 0 && !Object.is(object, -0) && !/e/i.test(object.toString(10))),
   represent: (object: number) => object.toString(10)
 })
 

--- a/src/tag/scalar/int_json.ts
+++ b/src/tag/scalar/int_json.ts
@@ -49,7 +49,9 @@ const intJsonTag = defineScalarTag('tag:yaml.org,2002:int', {
   implicitFirstChars: ['-', ...'0123456789'],
   resolve: resolveYamlInteger,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 === 0 && !Object.is(object, -0)),
+    // Large integers (>= 1e21) stringify in exponential notation, which is not
+    // valid `!!int` text. Reject them here so they fall through to the float tag.
+    (object % 1 === 0 && !Object.is(object, -0) && !/e/i.test(object.toString(10))),
   represent: (object: number) => object.toString(10)
 })
 

--- a/src/tag/scalar/int_yaml11.ts
+++ b/src/tag/scalar/int_yaml11.ts
@@ -48,7 +48,9 @@ const intYaml11Tag = defineScalarTag('tag:yaml.org,2002:int', {
   implicitFirstChars: ['-', '+', ...'0123456789'],
   resolve: resolveYamlInteger,
   identify: (object) => Object.prototype.toString.call(object) === '[object Number]' &&
-    (object % 1 === 0 && !Object.is(object, -0)),
+    // Large integers (>= 1e21) stringify in exponential notation, which is not
+    // valid `!!int` text. Reject them here so they fall through to the float tag.
+    (object % 1 === 0 && !Object.is(object, -0) && !/e/i.test(object.toString(10))),
   represent: (object: number) => object.toString(10)
 })
 

--- a/test/core/tags/int.test.mjs
+++ b/test/core/tags/int.test.mjs
@@ -39,6 +39,17 @@ describe('tags/int', () => {
         assert.deepStrictEqual(load(dump(expected, { schema }), { schema }), expected)
       })
 
+      it(`${name} round-trip of large integers`, () => {
+        // Integers at or above 1e21 stringify in exponential notation
+        // ('1e+21'), which is not valid `!!int` text. They must round-trip
+        // through the float tag rather than being dumped as `!!int '1e+21'`.
+        const large = [1e21, 1.5e21, -1e21, 1e100, Number.MAX_VALUE]
+
+        for (const value of large) {
+          assert.strictEqual(load(dump(value, { schema }), { schema }), value)
+        }
+      })
+
       it(`${name} fail explicit tag`, () => {
         assert.throws(() => load('!!int 1.5', { schema }), /cannot resolve/)
       })


### PR DESCRIPTION
## Problem

`load(dump(x))` throws on the library's own output for integer-valued numbers at or above `1e21`:

```js
const yaml = require('js-yaml')
yaml.dump(1e21)            // "!!int '1e+21'\n"
yaml.load(yaml.dump(1e21)) // YAMLException: cannot resolve a node with
                           // !<tag:yaml.org,2002:int> explicit tag
```

The boundary is exactly `1e21`: `1e20` dumps as `100000000000000000000` and round-trips fine, but `1e21` is the first integer whose `Number.prototype.toString(10)` switches to exponential notation (`"1e+21"`). The same break affects `1.5e21`, `-1e21`, `1e100`, and `Number.MAX_VALUE`, on the default, Core, JSON, and YAML 1.1 schemas.

## Root cause

The `!!int` tags identify a number as an integer with `object % 1 === 0`, which is true for `1e21`, and represent it with `object.toString(10)`, yielding the exponential text `1e+21`. On load, `1e+21` matches no `!!int` resolution pattern, so an explicit `!!int '1e+21'` cannot resolve.

Per YAML 1.2.2, `!!int` resolution accepts only decimal/octal/hex integer forms:

- [§10.3 Core schema](https://yaml.org/spec/1.2.2/#103-core-schema): `[-+]? [0-9]+ | 0o [0-7]+ | 0x [0-9a-fA-F]+`
- [§10.2 JSON schema](https://yaml.org/spec/1.2.2/#102-json-schema): `-? ( 0 | [1-9] [0-9]* )`

Exponential text such as `1e+21` matches none of these; it is a float. The float tags already guard the same hazard on output (`representYamlFloat` rewrites `1e+21` to the valid float form `1.e+21`), but the int tags do not, and the int tag is reached first because the float `identify` only claims non-integer numbers.

## Fix

Make the `!!int` tags reject numbers whose decimal stringification contains an exponent, and extend the `!!float` tags to claim them instead. The float `represent` already emits valid float text (`1.e+21`) for these values, so they now round-trip through the float tag.

This restores the "Ensure numbers survive round-trip" invariant (CHANGELOG, #737) for large integers.

## Verification

Added `round-trip of large integers` to `test/core/tags/int.test.mjs`, asserting `load(dump(value)) === value` for `[1e21, 1.5e21, -1e21, 1e100, Number.MAX_VALUE]` across the JSON, Core, and YAML 1.1 schemas.

- Before the fix: the new test fails with the `cannot resolve` exception above.
- After the fix: the new test passes and the full suite is green (`npm test`, 1594 passing, 0 failing).

`dist/` is gitignored, so no build artifacts are committed; regeneration is handled at publish.