### PR TITLE
fix: quote flow scalars where a colon precedes a flow indicator

### DIFF
--- a/src/ast/presenter.ts
+++ b/src/ast/presenter.ts
@@ -257,7 +257,14 @@ function isPlainSafe (c: number, prev: number, inblock: boolean) {
     !(prev === CHAR_COLON && !cIsNsChar)
   ) || // false on ': '
   (isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP) || // change to true on '[^ ]#'
-  (prev === CHAR_COLON && cIsNsChar) // change to true on ':[^ ]'
+  (prev === CHAR_COLON && cIsNsChar &&
+    // outside block context a following c-flow-indicator is not ns-plain-safe
+    (inblock ||
+      (c !== CHAR_COMMA &&
+       c !== CHAR_LEFT_SQUARE_BRACKET &&
+       c !== CHAR_RIGHT_SQUARE_BRACKET &&
+       c !== CHAR_LEFT_CURLY_BRACKET &&
+       c !== CHAR_RIGHT_CURLY_BRACKET))) // change to true on ':[^ ]'
 }
 
 // Simplified test for values allowed as the first character in plain style.

--- a/test/core/units/dump-options.test.mjs
+++ b/test/core/units/dump-options.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { dump, JSON_SCHEMA, CORE_SCHEMA, defineMappingTag, realMapTag, YAMLException } from 'js-yaml'
+import { dump, load, JSON_SCHEMA, CORE_SCHEMA, defineMappingTag, realMapTag, YAMLException } from 'js-yaml'
 
 describe('dump options', () => {
   it('schema — decides which plain scalars need quoting', () => {
@@ -94,6 +94,16 @@ describe('dump options', () => {
     assert.equal(dump({ a: [1, 2] }), 'a:\n  - 1\n  - 2\n')
     assert.equal(dump({ a: [1, 2] }, { flowLevel: 0 }), '{a: [1, 2]}\n')
     assert.equal(dump({ a: [1, 2] }, { flowLevel: 1 }), 'a: [1, 2]\n')
+  })
+
+  it('flowLevel — quotes a colon followed by a flow indicator', () => {
+    // In flow context a `:` followed by a flow indicator ({ } [ ] ,) is not
+    // plain-safe (ns-plain-safe-in excludes c-flow-indicator), so the value
+    // must be quoted for the output to re-parse.
+    for (const value of [':{', ':[', ':,', ':}', ':]', 'x:{']) {
+      assert.deepStrictEqual(load(dump([value], { flowLevel: 0 })), [value])
+      assert.deepStrictEqual(load(dump({ k: value }, { flowLevel: 0 })), { k: value })
+    }
   })
 
   it('transform — mutates the generated documents before presentation', () => {


### PR DESCRIPTION
## Problem

Flow-style dump produces output the library cannot re-parse when a plain scalar contains a `:` immediately followed by a flow indicator (`{ } [ ] ,`):

```js
const yaml = require('js-yaml')
yaml.dump([':{'], { flowLevel: 0 })       // "[:{]\n"
yaml.load(yaml.dump([':{'], { flowLevel: 0 }))
// YAMLException: missed comma between flow collection entries (1:4)
```

This breaks `load(dump(x))` for values such as `':{'`, `':['`, `':,'`, `':}'`, `':]'`, and `'x:{'`, in both flow sequences and flow mappings. Block style is unaffected — there the scalar stays plain and round-trips fine, which is correct.

## Root cause

`isPlainSafe` in `src/ast/presenter.ts` decides whether a character may appear unescaped in a plain scalar. Its last clause implements the spec's `ns-plain-char` rule for a `:` followed by content:

```
[130] ns-plain-char(c) ::= ... | ( ":" /* Followed by an ns-plain-safe(c) */ )
```

The clause was `(prev === CHAR_COLON && cIsNsChar)`, i.e. it treated *any* ns-char after a colon as safe. But `ns-plain-safe(c)` is context-dependent:

- [128] `ns-plain-safe-out ::= ns-char` (block context)
- [129] `ns-plain-safe-in  ::= ns-char - c-flow-indicator` (flow context)

In flow context the following character must additionally not be a flow indicator. Because the clause skipped that exclusion, `{ } [ ] ,` after a `:` were wrongly accepted, so the scalar was emitted plain and the `{`/`[`/`,` reopened or closed the surrounding flow collection.

## Fix

Add the `c-flow-indicator` exclusion to the colon clause when not in block context, matching `ns-plain-safe-in`. The `#`-after-colon case (`:#`) and normal `:x` stay plain; flow indicators after a colon now force quoting.

## Verification

Added `flowLevel — quotes a colon followed by a flow indicator` to `test/core/units/dump-options.test.mjs`, asserting `load(dump(value, { flowLevel: 0 })) === value` for the affected strings in flow sequences and mappings.

- Before: the new test throws `missed comma between flow collection entries`.
- After: it passes; full suite green (`npm test`, 1599 passing, 0 failing). No over-quoting — `:a`, `a:b`, `:#`, `http://x` remain plain in flow.

`dist/` is gitignored, so no build artifacts are committed.
