### PR TITLE
Fix !!timestamp resolution for years 0000-0099

### DIFF
--- a/src/tag/scalar/timestamp.ts
+++ b/src/tag/scalar/timestamp.ts
@@ -27,6 +27,10 @@ function resolveYamlTimestamp (source: string) {
   // Date-only form (`YYYY-MM-DD`) has no time captures.
   if (!match[4]) {
     const date = new Date(Date.UTC(year, month, day))
+    // Date.UTC() maps years 0-99 into 1900-1999; restore the intended year so
+    // low four-digit years (e.g. 0001) resolve correctly. Passing month/day
+    // re-checks the leap day against the real year.
+    if (year >= 0 && year <= 99) date.setUTCFullYear(year, month, day)
     // Reject dates that JS would normalize, e.g. 2023-02-29 -> 2023-03-01.
     if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) {
       return NOT_RESOLVED
@@ -49,6 +53,11 @@ function resolveYamlTimestamp (source: string) {
   }
 
   const date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction))
+
+  // Date.UTC() maps years 0-99 into 1900-1999; restore the intended year so
+  // low four-digit years (e.g. 0001) resolve correctly. Passing month/day
+  // re-checks the leap day against the real year.
+  if (year >= 0 && year <= 99) date.setUTCFullYear(year, month, day)
 
   // Reject invalid calendar dates before applying timezone offset.
   if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month || date.getUTCDate() !== day) {

--- a/test/core/tags/timestamp.test.mjs
+++ b/test/core/tags/timestamp.test.mjs
@@ -44,6 +44,35 @@ describe('tags', () => {
     assert.throws(() => { load('!!timestamp', { schema: YAML11_SCHEMA }) }, YAMLException)
   })
 
+  it('timestamp: years 0-99 are not remapped into the 1900s', () => {
+    // Build expected dates without Date.UTC(), whose two-digit-year legacy
+    // behaviour is exactly what we are guarding against.
+    const utc = (y, mo, d, h = 0, mi = 0, s = 0, ms = 0) => {
+      const date = new Date(0)
+      date.setUTCFullYear(y, mo, d)
+      date.setUTCHours(h, mi, s, ms)
+      return date
+    }
+
+    // Valid four-digit years below 100 must resolve to the real year, not
+    // 1900 + year.
+    assert.deepStrictEqual(load('0001-01-01', { schema: YAML11_SCHEMA }), utc(1, 0, 1))
+    assert.deepStrictEqual(load('0050-06-15T12:30:00Z', { schema: YAML11_SCHEMA }), utc(50, 5, 15, 12, 30, 0))
+    assert.deepStrictEqual(load('0099-12-31', { schema: YAML11_SCHEMA }), utc(99, 11, 31))
+    // Leap day valid in the real year (year 4 is a leap year).
+    assert.deepStrictEqual(load('0004-02-29', { schema: YAML11_SCHEMA }), utc(4, 1, 29))
+
+    // Invalid calendar dates in the low-year range are still rejected (year 1
+    // is not a leap year), i.e. left as a plain string.
+    assert.strictEqual(load('0001-02-29', { schema: YAML11_SCHEMA }), '0001-02-29')
+
+    // And such dates survive a dump -> load round-trip.
+    const dates = [utc(1, 0, 1), utc(50, 5, 15, 12, 30, 0), utc(99, 11, 31)]
+    assert.deepStrictEqual(
+      load(dump(dates, { schema: YAML11_SCHEMA }), { schema: YAML11_SCHEMA }),
+      dates)
+  })
+
   it('timestamp rejects values normalized by Date', () => {
     const invalid = [
       '2023-99-99',


### PR DESCRIPTION
While round-tripping `Date` values through `YAML11_SCHEMA` I hit a case where a date in years 1–99 throws on reload:

```js
const d = new Date(0); d.setUTCFullYear(50, 0, 1)
load(dump(d, { schema: YAML11_SCHEMA }), { schema: YAML11_SCHEMA })
// -> throws: cannot resolve a node with !<tag:yaml.org,2002:timestamp> explicit tag
```

And loading a valid low-year timestamp directly silently yields a string instead of a `Date`:

```js
load('0001-01-01', { schema: YAML11_SCHEMA }) // -> '0001-01-01' (string), expected a Date
```

Root cause: `resolveYamlTimestamp` builds the date with `Date.UTC(year, …)`, which applies JavaScript's legacy two-digit-year remap (0–99 → 1900–1999). The Date is then off by ~1900 years, so the calendar-normalization guard (`getUTCFullYear() !== year`) rejects the value and it falls back to a plain string. During `dump` that same rejection forces an explicit `!!timestamp` tag onto the scalar, which then can't resolve on load — hence the throw.

Fix: restore the intended year with `setUTCFullYear(year, month, day)` before the validity check. Passing month/day re-applies the day in the context of the real year, so invalid calendar dates like `0001-02-29` are still rejected.

Tested with `npm test` (all green). Extended `test/core/tags/timestamp.test.mjs` with low-year load cases, a leap day (`0004-02-29`), rejection of an invalid low-year date, and a dump → load round-trip.
