### PR TITLE
Allow a local key to override a merged non-string key

### DIFF
--- a/src/parser/constructor.ts
+++ b/src/parser/constructor.ts
@@ -264,7 +264,7 @@ function mergeKeys (state: ConstructorState, frame: MappingFrame, source: unknow
 
     const err = frame.tag.addPair(frame.value, sourceKey, sourceTag.get(source, sourceKey))
     if (err) throwError(state, err)
-    ;(frame.overridable ??= new Set()).add(sourceKey)
+    ;(frame.overridable ??= new Set()).add(frame.tag.normalizeKey(sourceKey))
   }
 }
 
@@ -295,13 +295,13 @@ function addMappingValue (state: ConstructorState, frame: MappingFrame, key: unk
     return
   }
 
-  if (!state.json && frame.tag.has(frame.value, key) && !frame.overridable?.has(key)) {
+  if (!state.json && frame.tag.has(frame.value, key) && !frame.overridable?.has(frame.tag.normalizeKey(key))) {
     throwError(state, 'duplicated mapping key')
   }
 
   const err = frame.tag.addPair(frame.value, key, value)
   if (err) throwError(state, err)
-  frame.overridable?.delete(key)
+  frame.overridable?.delete(frame.tag.normalizeKey(key))
 }
 
 function addValue (state: ConstructorState, value: unknown, tag: AnyTag) {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -58,6 +58,11 @@ interface MappingTagDefinition<Carrier = unknown, Result = Carrier> {
   has: (carrier: Carrier, key: unknown) => boolean
   keys: (result: Result) => Iterable<unknown>
   get: (result: Result, key: unknown) => unknown
+  // Canonical identity of a key, used when tracking merge-overridable keys.
+  // For object-based maps a resolved key (e.g. the number 10) and the string
+  // form it is stored under ("10") are the same key, so they must normalize
+  // alike; real Map/Set keys are already identity.
+  normalizeKey: (key: unknown) => unknown
   finalize: (carrier: Carrier) => Result
   carrierIsResult: boolean
   identify: IdentifyFn | null
@@ -112,6 +117,7 @@ type MappingTagOptions<Carrier, Result = Carrier> = {
   has: MappingTagDefinition<Carrier, Result>['has']
   keys: MappingTagDefinition<Carrier, Result>['keys']
   get: MappingTagDefinition<Carrier, Result>['get']
+  normalizeKey?: MappingTagDefinition<Carrier, Result>['normalizeKey']
   finalize?: MappingTagDefinition<Carrier, Result>['finalize']
 } & RepresentOptions<Result, Map<unknown, unknown>, MappingRepresent>
 
@@ -160,6 +166,7 @@ function defineMappingTag<Carrier, Result = Carrier> (tagName: string, options: 
     has: options.has,
     keys: options.keys,
     get: options.get,
+    normalizeKey: options.normalizeKey ?? (key => key),
     finalize: options.finalize ?? (carrier => carrier as unknown as Result),
     carrierIsResult,
     identify: options.identify ?? null,

--- a/src/tag/mapping/legacy_map.ts
+++ b/src/tag/mapping/legacy_map.ts
@@ -61,7 +61,8 @@ const legacyMapTag = defineMappingTag('tag:yaml.org,2002:map', {
     return normalizedKey !== null && Object.prototype.hasOwnProperty.call(container, normalizedKey)
   },
   keys: (container) => Object.keys(container),
-  get: (container, key) => container[String(key)]
+  get: (container, key) => container[String(key)],
+  normalizeKey
 })
 
 export { legacyMapTag, isPlainObject, type StringMapping }

--- a/src/tag/mapping/map.ts
+++ b/src/tag/mapping/map.ts
@@ -35,7 +35,8 @@ const mapTag = defineMappingTag('tag:yaml.org,2002:map', {
     return Object.prototype.hasOwnProperty.call(container, String(key))
   },
   keys: (container) => Object.keys(container),
-  get: (container, key) => container[String(key)]
+  get: (container, key) => container[String(key)],
+  normalizeKey: (key) => (key !== null && typeof key === 'object' ? key : String(key))
 })
 
 export { mapTag, isPlainObject, type StringMapping }

--- a/test/core/tags/merge.test.mjs
+++ b/test/core/tags/merge.test.mjs
@@ -58,6 +58,28 @@ foo: bar
     )
   })
 
+  it('a local key overrides a merged non-string key', () => {
+    // An overridable key resolved to a number (10) or boolean (true) is stored
+    // under its string form; overriding it with an explicit pair must not raise
+    // "duplicated mapping key".
+    const src = `
+base: &a {10: x, true: y}
+merged:
+  <<: *a
+  10: X
+  true: Y
+`
+    const expected = {
+      base: { 10: 'x', true: 'y' },
+      merged: { 10: 'X', true: 'Y' }
+    }
+
+    assert.deepStrictEqual(
+      load(src, { schema: CORE_SCHEMA.withTags(mergeTag) }),
+      expected
+    )
+  })
+
   it('throws when the target mapping tag rejects a merged pair', () => {
     const src = `
 --- !!set


### PR DESCRIPTION
### Problem

A merge key (`<<`) folds another mapping's keys into the target and records them
as *overridable*, so a later explicit pair may override a merged key without a
`duplicated mapping key` error (the canonical YAML merge "Override" behavior).

For the default object-based map, that tracking breaks on **non-string** keys:

```js
const { load, CORE_SCHEMA, mergeTag } = require('js-yaml');
const schema = CORE_SCHEMA.withTags(mergeTag);

load('base: &a {10: x}\nm:\n  <<: *a\n  10: y', { schema });
// throws YAMLException: duplicated mapping key
```

A string key in the same position works fine (`ten:` → `{ten: 'y'}`). Non-string
map keys are ordinary in YAML (`on/off/yes/no`, port numbers, numeric enum keys).

### Root cause

The overridable set is populated from `keys()`, which for the object map is
`Object.keys()` — always **strings** (`"10"`). The duplicate check then queries
that set with the **resolved** key (the number `10`):

```ts
if (!state.json && frame.tag.has(frame.value, key) && !frame.overridable?.has(key)) {
  throwError(state, 'duplicated mapping key')
}
```

`frame.tag.has` coerces (`String(key)`) so it correctly sees the duplicate, but
`Set.has` uses SameValueZero, so `"10" !== 10` — the override exemption misses
and the pair is rejected. `realMapTag`/`setTag` store keys losslessly, so they
were never affected, which pinpoints the object-map string coercion as the cause.

### Fix

Object-based maps already normalize keys to their string form in
`addPair`/`has`/`get`. Give a mapping tag a `normalizeKey` (defaulting to
identity, so `Map`/`Set` tags are unchanged) and key the overridable set through
it, so both sides use the same key identity.

- Genuine duplicate keys without a merge still raise (`{10: x, 10: y}` throws).
- String-key overrides are unchanged.

### Test

Added a `tags/merge` case where a merged `10:`/`true:` is overridden by a local
pair. Fails on `main` (`duplicated mapping key`), passes with the fix. Full
`test/core` suite green (284 pass / 0 fail), `type-check` and `lint` clean.
