### PR TITLE
fix: quote newline-only strings instead of block scalar

### DIFF
--- a/src/ast/presenter.ts
+++ b/src/ast/presenter.ts
@@ -433,6 +433,11 @@ function chooseScalarStyle (state: PresenterState, string: string, layout: Retur
   if (blockIndent > 9 && needIndentIndicator(string)) {
     return STYLE_DOUBLE
   }
+  // A string of only newlines dumps poorly as a block scalar (|+ with blank
+  // lines). Prefer a double-quoted escape instead (#534).
+  if (hasLineBreak && !hasFoldableLine && string.replace(/\n/g, '') === '') {
+    return STYLE_DOUBLE
+  }
   // At this point we know block styles are valid.
   // Prefer literal style unless we want to fold.
   return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL

--- a/test/core/ast/presenter.test.mjs
+++ b/test/core/ast/presenter.test.mjs
@@ -118,6 +118,12 @@ describe('ast presenter', () => {
     assert.equal(dump({ a: '' }, { schema }), "a: ''\n")
   })
 
+  it('quotes a newline-only string instead of using a block scalar', () => {
+    assert.equal(dump('\n'), '"\\n"\n')
+    assert.equal(dump({ x: '\n' }), 'x: "\\n"\n')
+    assert.equal(load(dump('\n')), '\n')
+  })
+
   it('applies flow recursively to descendants', () => {
     const documents = jsToAst([{ a: [1, 2], b: 'x\ny' }], CORE_SCHEMA)
     const node = documents[0].contents


### PR DESCRIPTION
## Summary

When dumping a string that contains only newline characters, the presenter was choosing a literal block scalar (`|+`), which is hard to read for a single `\n`. This change prefers double-quoted style for newline-only strings so `dump('\n')` produces `"\n"`.

## Test plan

- [x] `npm run build`
- [x] `node --test test/core/ast/presenter.test.mjs`

Fixes #534
