### PR TITLE
presenter: treat a tab-indented line in a folded scalar as more-indented

### DIFF
--- a/src/ast/presenter.ts
+++ b/src/ast/presenter.ts
@@ -523,7 +523,7 @@ function blockHeader (string: string, indentPerLevel: number) {
 // a blank line (two breaks). Encode each run of p literal `\n` as p+1 breaks and
 // indent the following content line so the continuation isn't read as a new node
 // (a bare break would yield invalid "deficient indentation" output).
-// `foldBlockScalar` can't be reused here: it treats a leading space as a
+// `foldBlockScalar` can't be reused here: it treats a leading white space as a
 // "more-indented" line and suppresses the doubling, which a flow scalar must not.
 function encodeFlowBreaks (string: string, indent: number) {
   let nextLF = string.indexOf('\n')
@@ -552,6 +552,13 @@ function dropEndingNewline (string: string) {
   return string[string.length - 1] === '\n' ? string.slice(0, -1) : string
 }
 
+// A more-indented line is one starting with white space: YAML 1.2.2 [175]
+// s-nb-spaced-text, whose [33] s-white is a space *or a tab*. Matches the
+// parser's test in getBlockValue().
+function isMoreIndented (char: string | undefined) {
+  return char === ' ' || char === '\t'
+}
+
 // Note: a long line without a suitable break point will exceed the width limit.
 // Pre-conditions: every char in str isPrintable, str.length > 0, width > 0.
 function foldBlockScalar (string: string, width: number) {
@@ -567,7 +574,7 @@ function foldBlockScalar (string: string, width: number) {
   lineRe.lastIndex = nextLF
   let result = foldLine(string.slice(0, nextLF), width)
   // If we haven't reached the first content line yet, don't add an extra \n.
-  let prevMoreIndented = string[0] === '\n' || string[0] === ' '
+  let prevMoreIndented = string[0] === '\n' || isMoreIndented(string[0])
   let moreIndented
 
   // rest of the lines
@@ -576,7 +583,7 @@ function foldBlockScalar (string: string, width: number) {
     const prefix = match[1]
     const line = match[2]
 
-    moreIndented = (line[0] === ' ')
+    moreIndented = isMoreIndented(line[0])
     result += prefix +
       ((!prevMoreIndented && !moreIndented && line !== '') ? '\n' : '') +
       foldLine(line, width)
@@ -591,10 +598,10 @@ function foldBlockScalar (string: string, width: number) {
 // otherwise settles for the shortest line over the limit.
 // NB. More-indented lines *cannot* be folded, as that would add an extra \n.
 function foldLine (line: string, width: number) {
-  if (line === '' || line[0] === ' ') return line
+  if (line === '' || isMoreIndented(line[0])) return line
 
-  // Since a more-indented line adds a \n, breaks can't be followed by a space.
-  const breakRe = / [^ ]/g // note: the match index will always be <= length-2.
+  // Since a more-indented line adds a \n, breaks can't be followed by white space.
+  const breakRe = / [^ \t]/g // note: the match index will always be <= length-2.
   let match
   // start is an inclusive index. end, curr, and next are exclusive.
   let start = 0

--- a/test/core/ast/presenter.test.mjs
+++ b/test/core/ast/presenter.test.mjs
@@ -128,6 +128,32 @@ describe('ast presenter', () => {
     assert.equal(present(documents, { schema: CORE_SCHEMA }), '[{a: [1, 2], b: "x\\ny"}]\n')
   })
 
+  it('keeps a tab-indented line in a folded scalar more-indented', () => {
+    const longTab = `\t${'word '.repeat(20).trim()}`
+    const spacedTab = `${'a'.repeat(90)} \tzzz`
+
+    // [source, value] — every source is already the canonical rendering of its
+    // value, so re-presenting it must reproduce it byte for byte.
+    const cases = [
+      // tab-indented line first, last, and between two folded lines
+      ['k: >\n  \t\n  detected\n', '\t\ndetected\n'],
+      ['k: >\n  detected\n  \tdeep\n', 'detected\n\tdeep\n'],
+      ['k: >\n  a\n  \tdeep\n  b\n', 'a\n\tdeep\nb\n'],
+      // over the line width, but a more-indented line is never folded
+      [`k: >\n  ${longTab}\n  tail\n`, `${longTab}\ntail\n`],
+      // folding here would start the next line with a tab, changing the value
+      [`k: >\n  ${spacedTab}\n`, `${spacedTab}\n`],
+      // controls: literal style and space indentation were always correct
+      ['k: |\n  a\n  \tdeep\n  b\n', 'a\n\tdeep\nb\n'],
+      ['k: >\n  a\n   deep\n  b\n', 'a\n deep\nb\n']
+    ]
+
+    for (const [source, value] of cases) {
+      assert.deepEqual(load(source, { schema: CORE_SCHEMA }), { k: value })
+      assert.equal(presentParsed(source), source)
+    }
+  })
+
   it('propagates seqNoIndent to nested sequences', () => {
     const documents = jsToAst([{ items: [{ a: 1 }] }], CORE_SCHEMA)
 


### PR DESCRIPTION
Round-tripping

```
k: >
  <TAB>
  detected
```

through `parseEvents` → `eventsToAst` → `present` emits a blank line before `detected`, so the value goes from `"\t\ndetected\n"` to `"\t\n\ndetected\n"`; with the tab line between two folded lines it costs two extra newlines. YAML 1.2.2 §8.1.3 defines a more-indented line by production [175] `s-nb-spaced-text`, whose leading [33] `s-white` is a space *or a tab*, and whose surrounding breaks are preserved ([177] `b-l-spaced`) rather than folded — `getBlockValue()` in the parser tests for both (`0x20 || 0x09`), but the presenter tested only for a space, at four sites in `foldBlockScalar`/`foldLine`, including the fold-point regexp `/ [^ ]/` which would break at the space in `aaa… \tzzz` and move the tab to the start of the next line. Enumerating every two-line block-scalar body over a 7-line alphabet in both block styles gave 84 parseable sources, of which 12 changed value through `present()` — all folded style, all involving a tab, literal style clean at 0/42; all 12 were confirmed against PyYAML 6.0.3 and ruamel.yaml 0.19.1 reading the emitted bytes, and all 12 round-trip after this change.

To be straight about the blast radius: `dump()` is not affected, since it routes tab-containing strings to double-quoted or literal style and never enters the folded path (0 of 41 distinct values from the same family broke either way), so this only reaches code that presents a parsed AST — exported and typed, but not documented in the README. I left `divergedFixtures` alone: R4YG's `dump` comparison still fails after the fix because the suite double-quotes that scalar while js-yaml faithfully keeps `>`, which is a genuine style divergence. (Its label there is "missing block scalar indent indicator", but a leading tab needs no indicator — indentation auto-detection only counts spaces — so R4YG was really this bug.) `npm test` goes from 1613 tests / 1600 pass / 0 fail to 1614 / 1601 / 0 fail with the added case, and reverting each of the four predicates on its own makes that case fail.
