### PR TITLE
fix: tag names matching Object.prototype members escape YAMLException

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -39,10 +39,13 @@ interface TagDefinitionListMap {
 }
 
 function createTagDefinitionMap (): TagDefinitionMap {
+  // Object.create(null) avoids inheriting Object.prototype members (constructor,
+  // toString, __proto__, ...), which would otherwise shadow the "unknown tag" lookup
+  // miss below for a document-controlled tag name that happens to match one of them.
   return {
-    scalar: {},
-    sequence: {},
-    mapping: {}
+    scalar: Object.create(null),
+    sequence: Object.create(null),
+    mapping: Object.create(null)
   }
 }
 

--- a/test/core/units/load-error.test.mjs
+++ b/test/core/units/load-error.test.mjs
@@ -152,6 +152,18 @@ x
   {
     name: 'tab indentation in a later block sequence entry',
     source: ' - foo\n \t- bar\n'
+  },
+  {
+    // An unregistered tag name that collides with an inherited Object.prototype
+    // member (constructor, toString, __proto__, valueOf, ...) must still be
+    // reported as an "unknown tag" YAMLException, not a raw TypeError from
+    // mistakenly dereferencing the inherited value as a tag definition.
+    name: 'unregistered scalar tag matching an Object.prototype member',
+    source: '!<constructor> x'
+  },
+  {
+    name: 'unregistered mapping tag matching an Object.prototype member',
+    source: '!<toString>\n  a: 1\n'
   }
 ]
 


### PR DESCRIPTION
## Summary

Fixes #782. YAML tag names are fully document-controlled (via verbatim tags `!<name>` or a `%TAG` shorthand). The tag lookup tables (`Schema.exact.{scalar,sequence,mapping}`) are built as plain object literals, which inherit from `Object.prototype`. So a tag name that happens to match an inherited member - `constructor`, `toString`, `__proto__`, `valueOf`, and others - resolves to that inherited value in `exact[tagName]` instead of falling through to the intended "unknown tag" error.

The inherited value is truthy, so `lookupTag()` accepts it as a real tag definition and dereferences it as one (`.resolve()` on the scalar path, `.create()` on the collection path), producing a raw `TypeError` that escapes the documented `YAMLException` contract every `load()`/`loadAll()` caller relies on for error handling.

```js
load('!<constructor> x')
// TypeError: scalarTag.resolve is not a function   (should be YAMLException: unknown scalar tag)

load('!<toString>\n  a: 1\n')
// TypeError: definition.tag.create is not a function   (should be YAMLException: unknown mapping tag)
```

## Fix

Build the lookup tables with `Object.create(null)` instead of `{}`, so they have no prototype chain to accidentally shadow the lookup. An unregistered tag name that happens to collide with an `Object.prototype` member now correctly falls through to the same "unknown tag" `YAMLException` as any other unregistered tag name.

## Test plan
- [x] Added 2 regression tests (scalar and mapping paths) asserting `load()` throws `YAMLException` for `!<constructor>` and `!<toString>`. Confirmed both fail with the exact reported `TypeError`s on the old code and pass with the fix.
- [x] Full test suite passes (286/287, 1 pre-existing skip unrelated to this change).
- [x] `tsc --noEmit` and `eslint` both clean.