### PR TITLE
fix: quote a flow mapping key once, in the key's own style

### DIFF
--- a/src/ast/presenter.ts
+++ b/src/ast/presenter.ts
@@ -120,7 +120,10 @@ interface PresenterOptions {
   flowSkipColonSpace?: boolean
 
   /**
-   * Quotes flow mapping keys: `{a: 1}` becomes `{"a": 1}`.
+   * Quotes flow mapping keys: `{a: 1}` becomes `{"a": 1}`. The key is written
+   * as a JSON-like node — double-quoted regardless of {@link quoteStyle},
+   * unless the node already carries a quoted style hint — so `:` may follow it
+   * directly (see {@link flowSkipColonSpace}).
    *
    * @defaultValue `false`
    */
@@ -543,6 +546,13 @@ function resolveScalarStyle (state: PresenterState, node: ScalarNode,
     if (node.style.folded) return STYLE_FOLDED
   }
 
+  // `quoteFlowKeys` applies to flow mapping keys (`iskey && !inblock`). The
+  // style is forced here rather than by wrapping the rendered text in quotes:
+  // escaping then matches the style, quoting is applied once, and a non-default
+  // tag is still printed, so the key keeps its value. Double-quoted is the only
+  // style that can hold every scalar, so no case has to fall back.
+  if (iskey && !inblock && state.quoteFlowKeys) return STYLE_DOUBLE
+
   const string = node.value
 
   if (string.length === 0) {
@@ -772,20 +782,18 @@ function writeFlowMapping (state: PresenterState, level: number, node: MappingNo
     let pairBuffer = ''
     if (result !== '') pairBuffer += `,${!state.flowSkipCommaSpace ? ' ' : ''}`
 
+    // `quoteFlowKeys` is applied while rendering the key (see
+    // resolveScalarStyle), not by wrapping the rendered text.
     const keyText = writeNode(state, level, key, { iskey: true })
     const explicitPair = keyText.length > 1024
 
-    if (explicitPair) {
-      pairBuffer += '? '
-    } else if (state.quoteFlowKeys) {
-      pairBuffer += '"'
-    }
+    if (explicitPair) pairBuffer += '? '
 
     const valueText = writeNode(state, level, value, {})
     // No separating space when the value renders empty (e.g. null → '').
     const sep = state.flowSkipColonSpace || valueText === '' ? '' : ' '
 
-    pairBuffer += `${keyText}${state.quoteFlowKeys && !explicitPair ? '"' : ''}:${sep}${valueText}`
+    pairBuffer += `${keyText}:${sep}${valueText}`
 
     result += pairBuffer
   }

--- a/test/core/ast/presenter.test.mjs
+++ b/test/core/ast/presenter.test.mjs
@@ -34,6 +34,26 @@ describe('ast presenter', () => {
     assert.deepEqual(load(output, { schema: CORE_SCHEMA }), { [key]: 'value' })
   })
 
+  it('keeps a quoted style hint on a quoteFlowKeys key', () => {
+    // `quoteFlowKeys` needs the key to be a JSON-like node so an adjacent `:`
+    // separates it from the value. A single-quoted scalar already is one, so a
+    // node that carries a quote style hint keeps it instead of being forced to
+    // double-quoted.
+    const input = "{'a b': 1, c: 2}"
+    const documents = eventsToAst(parseEvents(input, {}), { source: input, schema: CORE_SCHEMA })
+    const options = {
+      schema: CORE_SCHEMA,
+      flowLevel: 0,
+      quoteFlowKeys: true,
+      flowSkipColonSpace: true,
+      flowSkipCommaSpace: true
+    }
+    const output = present(documents, options)
+
+    assert.equal(output, '{\'a b\':1,"c":2}\n')
+    assert.deepEqual(load(output, { schema: CORE_SCHEMA }), { 'a b': 1, c: 2 })
+  })
+
   it('aligns a compact block-collection key with a wide indent', () => {
     const map = new Map([[[1, 2], new Map([['a', 1], ['b', 2]])]])
     const schema = CORE_SCHEMA.withTags(realMapTag)

--- a/test/core/units/dump-options.test.mjs
+++ b/test/core/units/dump-options.test.mjs
@@ -157,6 +157,28 @@ describe('dump options', () => {
     assert.equal(dump({ a: 1 }, { flowLevel: 0, quoteFlowKeys: true }), '{"a": 1}\n')
   })
 
+  it('quoteFlowKeys — quotes a key once, in the key style', () => {
+    // The key is rendered quoted, rather than wrapped in quotes afterwards, so
+    // a key that already needs quoting is not quoted twice and its escaping
+    // matches the style actually used.
+    const opts = { flowLevel: 0, quoteFlowKeys: true }
+    assert.equal(dump({ '*x': 1 }, opts), '{"*x": 1}\n')
+    assert.equal(dump({ 'a\\b': 1 }, opts), '{"a\\\\b": 1}\n')
+    assert.equal(dump({ 'a\nb': 1 }, opts), '{"a\\nb": 1}\n')
+    assert.equal(dump({ '': 1 }, opts), '{"": 1}\n')
+
+    // A non-string key keeps its tag, so quoting does not turn it into a string.
+    const schema = CORE_SCHEMA.withTags(realMapTag)
+    assert.equal(dump(new Map([[1, 'v']]), { ...opts, schema }), '{!!int "1": v}\n')
+
+    // `condenseFlow`'s v5 spelling: the key must be JSON-like for an adjacent
+    // `:` to separate it from the value.
+    const condensed = { ...opts, flowSkipCommaSpace: true, flowSkipColonSpace: true }
+    const value = { '*x': 1, 'a b': [true, null] }
+    assert.equal(dump(value, condensed), '{"*x":1,"a b":[true,null]}\n')
+    assert.deepEqual(load(dump(value, condensed)), value)
+  })
+
   it('tagBeforeAnchor — emits the tag before the anchor', () => {
     function Tagged () {}
     const schema = CORE_SCHEMA.withTags(defineMappingTag('!t', {


### PR DESCRIPTION
Fixes #786, where I've written up the full analysis, the grammar argument, the property-test numbers and the regression accounting.

Per CONTRIBUTING.md the issue comes first and this PR is not a request to merge ahead of that discussion — it's here so the diff is concrete while you decide whether you want the change at all. **Happy to close it and wait on #786, or drop it entirely, if you'd rather agree the scope first.** There is one judgement call in it that I'd particularly like you to overrule if you disagree (see below).

## The problem in three lines

```js
dump({ '*x': 1 },  { flowLevel: 0, quoteFlowKeys: true })                        // {"'*x'": 1}  -> loads as key `'*x'`
dump({ '*x': 1 },  { flowLevel: 0, quoteFlowKeys: true, quoteStyle: 'double' })  // {""*x"": 1}  -> unparseable
dump({ 'a\\b': 1 }, { flowLevel: 0, quoteFlowKeys: true })                       // {"a\b": 1}   -> key gains U+0008
```

`quoteFlowKeys` glues a `"` on each side of the **already-serialized** key text (`writeFlowMapping`, `presenter.ts:775-788` on master). That's a lexical op applied after serialization, so it's blind to what it wraps: an already-quoted key gets quoted twice, a plain key's inert backslash becomes an escape, a flow collection becomes a string, and a non-string key loses its tag — because `shouldPrintTag` (`presenter.ts:961`) only fires when the *style* is non-plain, and a wrapper doesn't change the style.

This matters because `quoteFlowKeys` is precisely the mechanism that makes `flowSkipColonSpace` legal: YAML 1.2 [148] `c-ns-flow-map-json-key-entry` only permits an adjacent `:` after a [160] `c-flow-json-node`, i.e. a quoted scalar or flow collection. Together the three options are the documented v5 spelling of v4's `condenseFlow`.

Over 100 000 generated values with that full spelling, 5.3.0 gives `invalid-yaml=9742 corrupt=7647 ok=82611` — 17.4% of dumps either can't be re-read or come back different. Not a v5 regression: 4.1.0 does the same via `condenseFlow: true`.

## The fix

Force the scalar **style** at selection time instead of wrapping text — one line in `resolveScalarStyle`, and both quote insertions deleted from `writeFlowMapping`:

```js
if (iskey && !inblock && state.quoteFlowKeys) return STYLE_DOUBLE
```

`iskey && !inblock` *is* "flow mapping key": only `writeFlowMapping` (no `block`) and `writeBlockMapping` (`block: true`) pass `iskey`, and it's the same derivation the function already does one line above for `singleLineOnly`.

The point of fixing it at this level is that nothing else needs special-casing: escaping is chosen by the style that renders it, quoting happens once, and the untouched tag rule now emits `{!!int "1": v}` so a non-string key keeps its type — which [160] licenses, since node properties may precede a JSON-like node. The patch mentions neither tags nor collections, yet `{!!int "1": v}`, `{[a, b]: v}` and `{{"x": 1}: v}` all start working.

**+7 / −5 in `src`**, plus two regression tests.

### The judgement call — please overrule if you disagree

I force double-quoted regardless of `quoteStyle`. The old wrapper always used `"`, and both the TSDoc example and the existing test assert `{"a": 1}` under the default `quoteStyle: 'single'`, so this way **no output that already worked changes at all**. Honouring `quoteStyle` is arguably more principled but rewrites every working `quoteFlowKeys` output to `{'a': 1}`. One-line switch either way.

The forcing applies only when the node has no style hint of its own — via the AST API a node already marked single-quoted stays single-quoted, which is still `c-flow-json-content` and still round-trips under `flowSkipColonSpace`. That's in the TSDoc and pinned by a test.

## Verification

- **Fail-then-pass on a rebuilt baseline.** The baseline bundle rebuilt from `origin/master` is sha256-identical to the published npm tarball (`7c5405f6b6e1aacfcd488520ec06c776ad738cc96001ebae4b6b3a636da0d3fb`); both new tests fail on it (`{"'*x'": 1}` vs `{"*x": 1}`, and `{"'a b'":1,...}` vs `{'a b':1,...}`) and pass here.
- **Full suite** (`npm test`, identical to CI): **1636 / 1623 pass / 0 fail / 13 skipped**, against a pristine-master baseline of 1634 / 1621 / 0 / 13 — delta is exactly the two added tests. Lint and `tsc --noEmit` clean; `typedoc` 0 errors (its 1 `SnippetMark` warning is pre-existing, untouched file).
- **Same property test, same seed, with the fix:** `invalid-yaml=0 corrupt=0 ok=100000`.
- **Differential**, baseline bundle vs fixed bundle from the same tree, 100 000 values × randomised dump options:

| | byte-identical | changed, base invalid YAML | changed, base corrupt | changed, anything else |
|---|---|---|---|---|
| `quoteFlowKeys: false` | 100000 | 0 | 0 | **0** |
| `quoteFlowKeys: true` | 94740 | 3877 | 1383 | **0** |

The default path is byte-for-byte unchanged; on the option path every changed byte belonged to output that was already unparseable or already lossy.

## Costs and caveats, stated plainly

- **One behaviour change beyond the broken cases.** Keys over 1024 chars take the `? key` explicit form, which previously suppressed quoting and now doesn't (`explicitPair` is decided from the rendered length, so the style must be chosen first). With a 1100-char plain key both forms round-trip under `quoteFlowKeys` alone; add `flowSkipColonSpace` and only the new one does — the old form loses the value to `null`. The existing test `keeps quoteFlowKeys outside an explicit long flow key` still passes, but only because its key contains `\n` and was double-quoted either way, so its title now misdescribes the behaviour. Say the word and I'll rename it here.
- **Long keys serialize ~4–5× slower on the `quoteFlowKeys` path.** 2000 keys × 1000 plain-safe chars: base 12.3–12.9 ms vs fix 58.2–62.1 ms (interleaved, repeated 3×). Keys that used to render plain or single-quoted now go through `escapeString`'s per-code-point loop instead of a plain copy or one native `.replace`. Short keys are ×1.0–×1.2; the default path is within noise and provably identical bytes. It's a constant factor, not a new complexity class — `escapeString` is a single pass with no regex, ≈12–13 ns/char flat from 10⁴ to 10⁶ chars. I didn't touch `escapeString`; optimising it belongs in a separate change.
- **Output size**: identical on the default path; shrinks where the old code double-quoted (×0.90–×0.93) and grows where escaping is now correct — ×1.06 on a 20 000-key backslash corpus, worst case ×1.99 for a key that is entirely backslashes or quotes (1008 B → 2010 B). Those bytes are the escaping the old output was missing.

### Out of scope / not verified

- **`flowSkipColonSpace` without `quoteFlowKeys` is still ambiguous** — `dump({a:1},{flowLevel:0,flowSkipColonSpace:true})` is `{a:1}`, which loads as `{'a:1': null}`. Unchanged by this patch and currently asserted as correct at `dump-options.test.mjs:152`. It's the only remaining round-trip failure class my fuzzer reports after this fix. Whether that option should imply key quoting is a design call, not a bug fix, so I left it alone — happy to open it separately.
- **Alias keys** (`*ref`) can't be made JSON-like at all, so `quoteFlowKeys` can't protect them under `flowSkipColonSpace`; they used to be wrapped and destroyed, now they're emitted as-is. The adjacent anchored-mapping-key case does improve (base `{"&ref_0 {"s": 1}": v1, …}` is invalid YAML; here `{&ref_0 {"s": 1}: v1, …}` parses). I did not test alias-as-key exhaustively.
- Only fast-check-generated values, no real-world corpus; no separate browser/UMD bundle benchmark; Node v26 locally, CI covers `lts/*`.

### Why the existing fuzzer didn't catch this

`test/core/dump-fuzzy.test.mjs` already lists `quoteFlowKeys: fc.boolean()`, but its `Load from dumped should be the original object` property is `it.skip`'d and the options record never sets `flowLevel` — so flow mappings are never emitted and the option is inert even when true.
