### PR TITLE
fix: treat a leading UTF-8 BOM as outside the first line

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1449,7 +1449,12 @@ function parseEvents (input: string, options: ParserOptions): Event[] {
   const nullpos = input.indexOf('\0')
   if (nullpos !== -1) YAMLException.throwAt(input, nullpos, 'null byte is not allowed in input', state.filename)
 
-  if (state.input.charCodeAt(state.position) === 0xFEFF) state.position++
+  // UTF-8 BOM is not content. Advance lineStart with position so the first
+  // line is not treated as indented by one (YAML 1.2.2 §5.2 / [3] c-byte-order-mark).
+  if (state.input.charCodeAt(state.position) === 0xFEFF) {
+    state.position++
+    state.lineStart = state.position
+  }
 
   while (state.position < state.length) {
     skipSeparationSpace(state, true)

--- a/test/core/units/load-other.test.mjs
+++ b/test/core/units/load-other.test.mjs
@@ -8,6 +8,12 @@ describe('core/units/load-other', () => {
     assert.deepStrictEqual(load('foo: bar\n'), { foo: 'bar' })
   })
 
+  it('BOM strip does not indent a multi-key mapping (#791)', () => {
+    const src = '\uFEFFabc: 5\ncba:\n  - Xyz\n  - Zyx\n'
+    assert.deepStrictEqual(load(src), { abc: 5, cba: ['Xyz', 'Zyx'] })
+    assert.deepStrictEqual(load(src.slice(1)), { abc: 5, cba: ['Xyz', 'Zyx'] })
+  })
+
   it('Loading multidocument source using `load` should cause an error', () => {
     assert.throws(() => {
       load('--- # first document\n--- # second document\n')


### PR DESCRIPTION
Fixes #791.

A leading UTF-8 BOM was skipped by advancing `position` only. `lineStart` stayed at 0, so the first content line was treated as indented by one column. A single-key mapping still parsed (`foo: bar`), but a second key at column 0 then failed with `end of the stream or a document separator is expected`.

`consumeLineBreak` already moves `lineStart` with `position` when a line actually starts. The BOM is not content (YAML 1.2.2 [3] `c-byte-order-mark`), so the first line starts after it.

```js
load('\uFEFFabc: 5\ncba:\n  - Xyz\n  - Zyx\n')
// before: YAMLException
// after:  { abc: 5, cba: ['Xyz', 'Zyx'] }
```

`npm test`: 1635 tests, 1622 pass, 0 fail, 13 skipped (the extra passing test is the regression).
