### PR TITLE
fix: honor sortKeys when deciding if a document is open-ended

### DIFF
--- a/src/ast/presenter.ts
+++ b/src/ast/presenter.ts
@@ -1005,15 +1005,17 @@ function rootStartsOwnLine (node: Node) {
 // A document whose serialization ends with a keep-chomped (`+`) block scalar is
 // open-ended: the trailing blank line(s) would otherwise be ambiguous, so it
 // needs a `...` terminator. Mirrors the keep test in `blockHeader`.
-function isOpenEnded (node: Node) {
+function isOpenEnded (node: Node, state: PresenterState) {
   // Descend to the last leaf, always taking the last item of a block collection
   // (a flow collection renders on one line, so it ends the document itself).
+  // Mapping order must match writeBlockMapping: sortKeys can change which
+  // value is actually rendered last (#789).
   let leaf = node
   while ((leaf.kind === 'sequence' || leaf.kind === 'mapping') &&
     !leaf.style.flow && leaf.items.length !== 0) {
     leaf = leaf.kind === 'sequence'
       ? leaf.items[leaf.items.length - 1]
-      : leaf.items[leaf.items.length - 1].value
+      : sortMappingItems(state, leaf.items)[leaf.items.length - 1].value
   }
 
   if (leaf.kind !== 'scalar' || !(leaf.style.literal || leaf.style.folded)) return false
@@ -1069,7 +1071,7 @@ function present (documents: Document[], options: PresenterOptions): string {
       result += writeNode(state, 0, doc.contents, { block: true, compact: true }) + '\n'
     }
 
-    previousEnded = doc.explicitEnd || (doc.contents !== null && isOpenEnded(doc.contents))
+    previousEnded = doc.explicitEnd || (doc.contents !== null && isOpenEnded(doc.contents, state))
     if (previousEnded) {
       result += '...\n'
     }

--- a/test/core/ast/presenter.test.mjs
+++ b/test/core/ast/presenter.test.mjs
@@ -64,6 +64,16 @@ describe('ast presenter', () => {
     assert.equal(output, 'a: 1\na: 2\n')
   })
 
+  it('uses the sorted last mapping value for open-ended detection (#789)', () => {
+    const source = 'b: |+\n  x\n\na: x\n'
+    const documents = eventsToAst(parseEvents(source, {}), { source, schema: CORE_SCHEMA })
+    documents.push(...jsToAst('next', CORE_SCHEMA))
+
+    const output = present(documents, { schema: CORE_SCHEMA, sortKeys: true })
+
+    assert.equal(output, 'a: x\nb: |+\n  x\n\n...\nnext\n')
+  })
+
   it('emits a bare marker for an explicit-start null document', () => {
     const output = present([{ contents: null, directives: [], explicitStart: true }], { schema: CORE_SCHEMA })
 


### PR DESCRIPTION
Fixes #789.

`writeBlockMapping` renders keys in `sortKeys` order, but `isOpenEnded()` still looked at `node.items[length - 1]`. If sorting moved a keep-chomped (`|+`) scalar to the end, the presenter did not emit `...` before the next document.

```js
const source = 'b: |+\n  x\n\na: x\n'
const documents = eventsToAst(parseEvents(source, {}), { source, schema: CORE_SCHEMA })
documents.push(...jsToAst('next', CORE_SCHEMA))
present(documents, { schema: CORE_SCHEMA, sortKeys: true })
// before: --- next
// after:  ...\nnext
```

`npm test`: 1635 tests, 1622 pass, 0 fail, 13 skipped.
