### PR TITLE
fix: count empty merge sources against maxTotalMergeKeys

### DIFF
--- a/src/parser/constructor.ts
+++ b/src/parser/constructor.ts
@@ -237,13 +237,20 @@ function isMappingTag (tag: AnyTag): tag is MappingTagDefinition<any, any> {
   return tag.nodeKind === 'mapping'
 }
 
+function chargeMergeKey (state: ConstructorState) {
+  if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) {
+    throwError(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`)
+  }
+}
+
 // Fold the keys of one mapping source into the target frame, honoring merge
 // precedence: an already-present key (explicit or from an earlier source) wins.
 function mergeKeys (state: ConstructorState, frame: MappingFrame, source: unknown, sourceTag: MappingTagDefinition<any, any>) {
+  let counted = false
+
   for (const sourceKey of sourceTag.keys(source)) {
-    if (state.maxTotalMergeKeys !== -1 && ++state.totalMergeKeys > state.maxTotalMergeKeys) {
-      throwError(state, `merge keys exceeded maxTotalMergeKeys (${state.maxTotalMergeKeys})`)
-    }
+    counted = true
+    chargeMergeKey(state)
 
     if (frame.tag.has(frame.value, sourceKey)) continue
 
@@ -251,6 +258,11 @@ function mergeKeys (state: ConstructorState, frame: MappingFrame, source: unknow
     if (err) throwError(state, err)
     ;(frame.overridable ??= new Set()).add(sourceKey)
   }
+
+  // A source that folds no keys still costs work to process, so charge one unit
+  // for it. Otherwise a sequence of empty mappings, re-merged through an alias,
+  // does O(sources) work per merge while never touching the key counter.
+  if (!counted) chargeMergeKey(state)
 }
 
 // The value of a `<<` key: either a mapping (fold its keys) or a sequence of

--- a/test/core/pathological.test.mjs
+++ b/test/core/pathological.test.mjs
@@ -55,5 +55,14 @@ describe('Pathological tests', () => {
         load(createMergeChain(100000), { schema: YAML11_SCHEMA })
       }, /merge keys exceeded maxTotalMergeKeys/)
     })
+
+    it('counts empty merge sources against maxTotalMergeKeys', () => {
+      const n = 20000
+      const src = 'arr: &arr [' + '{},'.repeat(n).slice(0, -1) + ']\n' +
+        'targets:\n' + '  - <<: *arr\n'.repeat(n)
+      assertYamlException(() => {
+        load(src, { schema: YAML11_SCHEMA })
+      }, /merge keys exceeded maxTotalMergeKeys/)
+    })
   })
 })


### PR DESCRIPTION
The `maxTotalMergeKeys` guard added for the quadratic merge-key DoS (GHSA-g796-fgmg-93mv, fixed in 5.2.0) charges the budget **once per folded key**. A merge source that folds **no** keys — an empty mapping — costs real work to process but never increments the counter, so the guard can be bypassed:

```yaml
arr: &arr [{}, {}, {}, ...]   # N empty mappings
targets:
  - <<: *arr                  # repeated K times
```

`mergeSource` iterates every element of the `<<:` sequence, and aliasing one N-element array of empty maps into K targets does `O(K*N)` work — none of it counted.

## Impact

With merge enabled (`YAML11_SCHEMA`, or `CORE_SCHEMA.withTags(mergeTag)` — the standard YAML-1.1 / v4-compat configuration), the load time scales quadratically:

| payload | time |
|---|---|
| N=K=800 (~13 KB) | ~20 ms |
| N=K=3200 (~50 KB) | ~180 ms |
| N=K=20000 (~500 KB) | **~13 s** |

A ~1 MB document projects to minutes of CPU on a single core. This restores the same availability DoS the `maxTotalMergeKeys` guard was shipped to prevent. A **real** key-folding merge of comparable size is correctly rejected today (`merge keys exceeded maxTotalMergeKeys`), so the guard works for the intended shape but is defeated by zero-key sources.

**Attacker → control:** attacker supplies an untrusted YAML document to an app that loads with merge enabled; the defeated control is `maxTotalMergeKeys` (default 10000).

## Fix

Track whether a source folded any keys; if it folded none, charge one unit for it. A sequence of empty mappings is then bounded by `maxTotalMergeKeys` like any other merge.

## Tests

A case in `test/core/pathological.test.mjs` (next to the existing merge-chain test) asserts the empty-source payload is rejected; it hangs for ~13 s and loads on the current code, and throws promptly with the fix. Normal and single empty-map merges still load correctly. Full suite green.
